### PR TITLE
Update dialog styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.7.1 (2020-09-21)
+
+### Bugfixes
+
+-   **Dialog**: updated dialog styles [jlp0328]
+
 # 2.7.0 (2020-09-21)
 
 ### Breaking changes

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/modal/dialog/dialog.component.scss
+++ b/projects/pastanaga-angular/src/lib/modal/dialog/dialog.component.scss
@@ -4,7 +4,8 @@
     text-align: center;
     min-width: rhythm(28);
     max-width: rhythm(32);
-    padding: rhythm(2);
+    padding: rhythm(3.5) rhythm(2.5) rhythm(2);
+    box-shadow: $shadow-modal;
 
     .pa-modal-header {
         h4 {
@@ -24,7 +25,7 @@
     pa-modal-footer {
         margin-top: rhythm(3.5);
         display: flex;
-        justify-content: space-between;
+        justify-content: center;
 
         pa-button:not(:last-of-type) {
             margin-right: rhythm(1);


### PR DESCRIPTION
[ch30454](https://app.clubhouse.io/onnahq/story/30454/padding-shadow-and-position-of-buttons-in-alert-dialog-don-t-currently-match-designs)