### PR TITLE
Add background color to pa-dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.14.2 (2020-12-07)
+
+### Bugfix
+
+-   **Modal**: Add background color for modal and dialog [jlp0328]
+
 # 2.14.1 (2020-12-04)
 
 ### Improvements

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.14.1",
+    "version": "2.14.2",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/modal/dialog/dialog.component.scss
+++ b/projects/pastanaga-angular/src/lib/modal/dialog/dialog.component.scss
@@ -6,6 +6,7 @@
     max-width: rhythm(32);
     padding: rhythm(3.5) rhythm(2.5) rhythm(2);
     box-shadow: $shadow-modal;
+    background-color: $color-neutral-primary-lightest;
 
     .pa-modal-header {
         h4 {

--- a/projects/pastanaga-angular/src/lib/modal/modal/modal.component.scss
+++ b/projects/pastanaga-angular/src/lib/modal/modal/modal.component.scss
@@ -4,6 +4,7 @@
     min-width: rhythm(48);
     position: relative;
     padding: rhythm(2.5) rhythm(4);
+    background-color: $color-neutral-primary-lightest;
 
     .pa-close-button {
         position: absolute;


### PR DESCRIPTION
Fix for [ch37539](https://app.clubhouse.io/onnahq/story/37539/pa-dialogs-on-iphone-se-ipad-pro-are-transparent)