### PR TITLE
Dropdown fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.17.7 (2021-01-07)
+
+### Bugfix
+
+- **Popup**: Fix width and position of dropdown [jlp0328]
+
 # 2.17.6 (2021-01-07)
 
 ### Improvement

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.17.6",
+    "version": "2.17.7",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -15,6 +15,7 @@
          [popupPosition]="{position: 'absolute', left: '0', right: '0', top: '48px'}"
          [popupDisabled]="control.disabled || _readonly"
          cdkMonitorElementFocus
+         sameWidth
          (cdkFocusChange)="onFocus($event)">
         <span class="select-value"
               [class.placeholder]="!selectedLabel"

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -69,7 +69,9 @@ export class PopupDirective implements OnInit {
                 if (this.paPopup._isDisplayed) {
                     this.paPopup.close();
                 } else {
-                    this.paPopup.show(this.getPosition($event));
+                    let position: PositionStyle;
+                    position = this.getPosition();
+                    this.paPopup.show(position);
                 }
             }
         }
@@ -80,9 +82,9 @@ export class PopupDirective implements OnInit {
     }
 
     @HostListener('mouseenter', ['$event'])
-    onHover($event: MouseEvent) {
+    onHover() {
         if (this._openOnHover && !this._disabled && !this.paPopup?._isDisplayed) {
-            this.paPopup?.show(this.getPosition($event));
+            this.paPopup?.show(this.getPosition());
         }
     }
     @HostListener('mouseleave')
@@ -92,7 +94,7 @@ export class PopupDirective implements OnInit {
         }
     }
 
-    getPosition(contextualEvent?: MouseEvent): PositionStyle {
+    getPosition(contextualEvent?: MouseEvent | false): PositionStyle {
         const directiveElement: HTMLElement = this.element.nativeElement;
         const clickedElement: HTMLElement = this._remoteElement || directiveElement;
         const rect = contextualEvent
@@ -103,6 +105,7 @@ export class PopupDirective implements OnInit {
                   right: contextualEvent.x,
               }
             : clickedElement.getBoundingClientRect();
+
         if (!this._rootParent) {
             this._rootParent = getPositionedParent(directiveElement.parentElement || directiveElement);
         }
@@ -116,6 +119,7 @@ export class PopupDirective implements OnInit {
             bottom: this.popupOnTop ? bottom - MARGIN + 'px' : undefined,
             width: this._sameWidth ? rect.right - rect.left + 'px' : undefined,
         };
+
         if (this._popupOnRight || !!contextualEvent) {
             position.left = Math.min(rect.left - rootRect.left, window.innerWidth - 240) + 'px';
         } else {

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -69,8 +69,7 @@ export class PopupDirective implements OnInit {
                 if (this.paPopup._isDisplayed) {
                     this.paPopup.close();
                 } else {
-                    let position: PositionStyle;
-                    position = this.getPosition();
+                    const position: PositionStyle = this.getPosition();
                     this.paPopup.show(position);
                 }
             }
@@ -94,17 +93,10 @@ export class PopupDirective implements OnInit {
         }
     }
 
-    getPosition(contextualEvent?: MouseEvent | false): PositionStyle {
+    getPosition(): PositionStyle {
         const directiveElement: HTMLElement = this.element.nativeElement;
         const clickedElement: HTMLElement = this._remoteElement || directiveElement;
-        const rect = contextualEvent
-            ? {
-                  top: contextualEvent.y,
-                  bottom: contextualEvent.y,
-                  left: contextualEvent.x,
-                  right: contextualEvent.x,
-              }
-            : clickedElement.getBoundingClientRect();
+        const rect = clickedElement.getBoundingClientRect();
 
         if (!this._rootParent) {
             this._rootParent = getPositionedParent(directiveElement.parentElement || directiveElement);
@@ -120,7 +112,7 @@ export class PopupDirective implements OnInit {
             width: this._sameWidth ? rect.right - rect.left + 'px' : undefined,
         };
 
-        if (this._popupOnRight || !!contextualEvent) {
+        if (this._popupOnRight) {
             position.left = Math.min(rect.left - rootRect.left, window.innerWidth - 240) + 'px';
         } else {
             position.right = Math.min(rootRect.right - rect.right + 3, window.innerWidth - 240) + 'px';


### PR DESCRIPTION
Reverting some of the changes from the previous version. 

Fixes are tied to [ch39362](https://app.clubhouse.io/onnahq/story/39362/pa-dropdown-out-of-alignment-on-various-components)

Note: reverting to pastanaga version 2.17.5 also amends the issue