### PR TITLE
apply validators when changed at run time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.21.0 (2021-02-17)
+
+### Bugfix:
+- **Controls**: Apply validators when changed at run time [dgsmith2]
+
 # 2.20.2 (2021-02-16)
 
 ### Bugfix:

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.20.2",
+    "version": "2.21.0",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/base-control.ts
+++ b/projects/pastanaga-angular/src/lib/controls/base-control.ts
@@ -394,9 +394,7 @@ export abstract class BaseControl implements OnChanges, OnInit, OnDestroy, Contr
             this.control.setAsyncValidators(this._parentAsyncValidator);
         }
 
-        if (this.control.dirty) {
-            this.control.updateValueAndValidity();
-        }
+        this.control.updateValueAndValidity();
     }
 
     /**


### PR DESCRIPTION
AbstractControl.setValidators dictates that updateValueAndValidity must be called for changes to take effect