### PR TITLE
change chip max-width to be working on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.23.7 (2021-03-12)
+
+### Bugfix
+- **Chips**: change chip max-width to be working on mobile without impacting chip look and feel when container is flex [mpellerin42]
+
 # 2.23.6 (2021-03-12)
 
 ### Bugfix

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.23.6",
+    "version": "2.23.7",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/styles/_chips.scss
+++ b/projects/pastanaga-angular/src/lib/styles/_chips.scss
@@ -1,13 +1,14 @@
 @import "variables";
 
-$chip-max-width: rhythm(56);
+$chip-max-width-small: rhythm(32);
+$chip-max-width-medium: rhythm(56);
 
 .pa-chip {
     display: inline-flex;
     align-items: center;
     background: $color-neutral-primary-lighter;
     height: rhythm(4);
-    max-width: Min(#{$chip-max-width}, 100%);
+    max-width: $chip-max-width-small;
     padding: rhythm(.5) rhythm(1.5);
     border-radius: rhythm(5);
     overflow: hidden;

--- a/projects/pastanaga-angular/src/lib/styles/_chips.scss
+++ b/projects/pastanaga-angular/src/lib/styles/_chips.scss
@@ -48,3 +48,10 @@ $chip-max-width-medium: rhythm(56);
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+
+
+@media (min-width: $size-viewport-medium-min) {
+    .pa-chip {
+        max-width: $chip-max-width-medium;
+    }
+}


### PR DESCRIPTION
Previous fix had a bad impact on chip look and feel when container is flex