### PR TITLE
use `input` event instead of `keyup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.29.7 (2021-05-19)
+
+### Bugfix
+- **Input Formatter**: Use `input` event [dgsmith2]
+
 # 2.29.6 (2021-05-19)
 
 ### Improvements

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.29.6",
+    "version": "2.29.7",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input-formatter.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input-formatter.directive.ts
@@ -6,6 +6,7 @@ const FORMATTER_CONTROL_VALUE_ACCESSOR: Provider = {
     useExisting: forwardRef(() => InputFormatterDirective),
     multi: true,
 };
+
 @Directive({
     selector: '[paInputFormatter]',
     providers: [FORMATTER_CONTROL_VALUE_ACCESSOR],
@@ -16,7 +17,7 @@ export class InputFormatterDirective implements ControlValueAccessor {
 
     private _writeToFormControl: (value: any) => void = () => {};
 
-    @HostListener('keyup') onKeyup() {
+    @HostListener('input') onKeyup() {
         const val = this.formatValue(this.el.nativeElement.value);
         if (val !== this.el.nativeElement.value) {
             this.el.nativeElement.value = val;


### PR DESCRIPTION
This allows changes/validation to be triggered when values aren't added via keyboard (e.g., pasting via the context menu)