### PR TITLE
Confirmation dialog fix and improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.33.1 (2021-06-14)
+
+### Improvements
+- **Confirmation dialog**: Accept HTML on confirmation dialog description [mpellerin42]
+
+### Bugfix
+- **Confirmation dialog**: Emit `onClose` when closing the dialog [mpellerin42]
+
 # 2.33.0 (2021-06-14)
 
 ### Feature

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.33.0",
+    "version": "2.33.1",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.html
+++ b/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.html
@@ -24,10 +24,10 @@
         <footer class="pa-modal-footer">
             <pa-button kind="secondary"
                        qa="confirmation-dialog-cancel-button"
-                       (click)="close(false)">{{ (ref.config.data?.cancelLabel || 'pastanaga.cancel') | translate}}</pa-button>
+                       (click)="ref.close(false)">{{ (ref.config.data?.cancelLabel || 'pastanaga.cancel') | translate}}</pa-button>
             <pa-button [kind]="ref.config.data?.isDestructive ? 'destructive' : 'primary'"
                        qa="confirmation-dialog-confirm-button"
-                       (click)="close(true)">{{ (ref.config.data?.confirmLabel || 'pastanaga.confirm') | translate}}</pa-button>
+                       (click)="ref.close(true)">{{ (ref.config.data?.confirmLabel || 'pastanaga.confirm') | translate}}</pa-button>
         </footer>
     </dialog>
 </div>

--- a/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.html
+++ b/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.html
@@ -17,9 +17,9 @@
 
         <div class="pa-modal-description body-s"
              qa="confirmation-description"
-             [id]="'dialog-' + id + '-description'">
-            {{ref.config.data?.description | translate}}
-        </div>
+             [id]="'dialog-' + id + '-description'"
+             [innerHTML]="ref.config.data?.description | translate"
+        ></div>
 
         <footer class="pa-modal-footer">
             <pa-button kind="secondary"

--- a/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/modal/confirmation-dialog/confirmation-dialog.component.spec.ts
@@ -109,17 +109,17 @@ describe('ConfirmationDialogComponent', () => {
 
     describe('actions', () => {
         beforeEach(() => {
-            spyOn(component, 'close');
+            spyOn(component.ref, 'close');
         });
 
         it('should close with false when clicking on cancel', () => {
             spectator.click('[qa="confirmation-dialog-cancel-button"]');
-            expect(component.close).toHaveBeenCalledWith(false);
+            expect(component.ref.close).toHaveBeenCalledWith(false);
         });
 
         it('should close with true when clicking on confirm', () => {
             spectator.click('[qa="confirmation-dialog-confirm-button"]');
-            expect(component.close).toHaveBeenCalledWith(true);
+            expect(component.ref.close).toHaveBeenCalledWith(true);
         });
     });
 });


### PR DESCRIPTION
### Improvements
- **Confirmation dialog**: Accept HTML on confirmation dialog description 

### Bugfix
- **Confirmation dialog**: Emit `onClose` when closing the dialog 