### PR TITLE
adjusting styling for small size buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.36.18 (2021-08-31)
+### Improvements
+- **Button**: updating small size button styling [faustoonna]
+
 # 2.36.17 (2021-08-26)
 
 ### Bugfix

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.36.17",
+    "version": "2.36.18",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/button/button.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/button/button.component.spec.ts
@@ -24,9 +24,7 @@ describe('ButtonComponent', () => {
         expect(component._iconSize).toEqual(Size.large);
         component.size = Size.medium;
         expect(component._iconSize).toEqual(Size.medium);
-    });
-    it('should set the icon size to medium for small buttons', () => {
         component.size = Size.small;
-        expect(component._iconSize).toEqual(Size.medium);
+        expect(component._iconSize).toEqual(Size.small);
     });
 });

--- a/projects/pastanaga-angular/src/lib/button/button.component.ts
+++ b/projects/pastanaga-angular/src/lib/button/button.component.ts
@@ -31,8 +31,10 @@ export class ButtonComponent implements AfterContentInit, OnInit {
                     this._iconSize = Size.large;
                     break;
                 case Size.medium:
-                case Size.small:
                     this._iconSize = Size.medium;
+                    break;
+                case Size.small:
+                    this._iconSize = Size.small;
                     break;
             }
         }

--- a/projects/pastanaga-angular/src/lib/styles/_buttons.scss
+++ b/projects/pastanaga-angular/src/lib/styles/_buttons.scss
@@ -39,7 +39,9 @@
         font-size: font-size(s);
         line-height: rhythm(3);
         padding: $padding-button-small;
-
+        &:not(.pa-button-icon):not(.pa-button-icon-text) {
+            min-width: auto;
+        }
         &.pa-button-icon {
             padding: $padding-button-icon-small;
         }

--- a/projects/pastanaga-angular/src/lib/styles/_buttons.scss
+++ b/projects/pastanaga-angular/src/lib/styles/_buttons.scss
@@ -31,7 +31,7 @@
     &.pa-button-icon {
         border-radius: 50%;
     }
-    &:not(.pa-button-icon):not(.pa-button-icon-text) {
+    &:not(.pa-button-icon):not(.pa-button-icon-text):not(.pa-small) {
         min-width: rhythm(20);
     }
 
@@ -39,9 +39,6 @@
         font-size: font-size(s);
         line-height: rhythm(3);
         padding: $padding-button-small;
-        &:not(.pa-button-icon):not(.pa-button-icon-text) {
-            min-width: auto;
-        }
         &.pa-button-icon {
             padding: $padding-button-icon-small;
         }

--- a/projects/pastanaga-angular/src/lib/styles/theme/_button.scss
+++ b/projects/pastanaga-angular/src/lib/styles/theme/_button.scss
@@ -156,7 +156,7 @@ $padding-button-icon-text-small:  rhythm(.5) rhythm(2) rhythm(.5) rhythm(1.5) !d
 $padding-button-icon-text-medium: rhythm(1) rhythm(2) rhythm(1) rhythm(1.5) !default;
 $padding-button-icon-text-large:  rhythm(1) rhythm(2) rhythm(1) rhythm(1.5)!default;
 
-$padding-button-icon-small:     rhythm(.5) !default;
+$padding-button-icon-small:     rhythm(1) !default;
 $padding-button-icon-medium:    rhythm(1.5) !default;
 $padding-button-icon-large:     rhythm(2) !default;
 

--- a/projects/pastanaga-angular/src/lib/styles/theme/_button.scss
+++ b/projects/pastanaga-angular/src/lib/styles/theme/_button.scss
@@ -148,11 +148,11 @@ $border-radius-button: 100px !default;
 // SPACING and SHADOWS
 //=====================================
 
-$padding-button-small:  rhythm(1) rhythm(2) !default;
+$padding-button-small:  rhythm(.5) rhythm(2) !default;
 $padding-button-medium: rhythm(1) rhythm(2) !default;
 $padding-button-large:  rhythm(1) rhythm(2) !default;
 
-$padding-button-icon-text-small:  rhythm(1) rhythm(2) rhythm(1) rhythm(1.5) !default;
+$padding-button-icon-text-small:  rhythm(.5) rhythm(2) rhythm(.5) rhythm(1.5) !default;
 $padding-button-icon-text-medium: rhythm(1) rhythm(2) rhythm(1) rhythm(1.5) !default;
 $padding-button-icon-text-large:  rhythm(1) rhythm(2) rhythm(1) rhythm(1.5)!default;
 


### PR DESCRIPTION
addressing new Design's requirement for small size buttons:
- Removing min-width;
- ensure that the button is 32px height;
- using small size icon for small size buttons