### PR TITLE
Fix popup and dropdown types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.36.26 (2021-09-14)
+
+### Bugfix
+- **Popup** / **Dropdown**: [mpellerin42]
+  - Add a new popupType `menu` so popups and menus are closed on `closeAllPopups` event, while dropdowns are not
+  - Set dropdown default `popupType` to `menu` instead of `dropdown`
+  - Update dropdown `popupType` when dropdown `role` changes
+
 # 2.36.25 (2021-09-13)
 
 ### Bugfix
@@ -7,7 +15,7 @@
 
 ### Improvements
 - **Popup**: [mpellerin42]
-  - Close only popups (not dropdowns) when receiving closeAllPopups event
+  - Close only popups (not dropdowns) when receiving `closeAllPopups` event
   - Decrease complexity in adjust popup method
 
 # 2.36.23 (2021-09-02)

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.36.25",
+    "version": "2.36.26",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -46,8 +46,7 @@
                  [adjustHeight]="adjustHeight"
                  [companionElement]="selectInput"
                  (onClose)="dropDownClosed()"
-                 (onOpen)="dropDownOpened()"
-                 >
+                 (onOpen)="dropDownOpened()">
 
         <ng-container *ngIf="dropDownModels.length; else contentOptions">
             <pa-select-options

--- a/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.ts
+++ b/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.ts
@@ -21,6 +21,7 @@ export class DropdownComponent extends PopupComponent implements OnInit, OnDestr
     @Input()
     set role(value: 'listbox' | 'menu') {
         this._role = value || 'menu';
+        this.popupType = value !== 'menu' ? 'dropdown' : 'menu';
     }
     get role(): 'listbox' | 'menu' {
         return this._role;
@@ -35,7 +36,7 @@ export class DropdownComponent extends PopupComponent implements OnInit, OnDestr
         protected cdr: ChangeDetectorRef,
     ) {
         super(popupService, renderer, element, cdr);
-        this.popupType = 'dropdown';
+        this.popupType = 'menu';
     }
 
     ngOnInit(): void {

--- a/projects/pastanaga-angular/src/lib/popup/popup.component.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.component.ts
@@ -53,7 +53,7 @@ export class PopupComponent implements OnInit, OnDestroy {
     @Output() onClose: EventEmitter<boolean> = new EventEmitter();
     @Output() onOpen: EventEmitter<void> = new EventEmitter();
 
-    set popupType(value: 'popup' | 'dropdown') {
+    set popupType(value: 'popup' | 'dropdown' | 'menu') {
         this._popupType = value;
     }
     get popupType() {
@@ -69,7 +69,7 @@ export class PopupComponent implements OnInit, OnDestroy {
 
     private _stayVisible = false;
     private _adjustHeight = false;
-    private _popupType: 'popup' | 'dropdown' = 'popup';
+    private _popupType: 'popup' | 'dropdown' | 'menu' = 'popup';
     private _originalHeight = 0;
     private _terminator = new Subject();
 
@@ -81,7 +81,7 @@ export class PopupComponent implements OnInit, OnDestroy {
     ) {
         this.popupService.closeAllPopups
             .pipe(
-                filter(() => this.popupType === 'popup'),
+                filter(() => this.popupType === 'popup' || this.popupType === 'menu'),
                 takeUntil(this._terminator),
             )
             .subscribe(() => this.close());


### PR DESCRIPTION

  - Add a new popupType `menu` so popups and menus are closed on `closeAllPopups` event, while dropdowns are not
  - Set dropdown default `popupType` to `menu` instead of `dropdown`
  - Update dropdown `popupType` when dropdown `role` changes