### PR TITLE
Fixed first error state not displayed after pristine using updateOn blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.39.3 (2021-12-09)
+
+### Bugfix
+- **Native text field**: fixed error state not displayed with updateOn blur [jCarret]
+
 # 2.39.2 (2021-11-17)
 
 ### Improvement

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.39.2",
+    "version": "2.39.3",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/native-text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/native-text-field.directive.ts
@@ -136,8 +136,13 @@ export class NativeTextFieldDirective extends PaFormControlDirective implements 
         this.blurring.emit(value);
         this._checkIsFilled();
         if (this.control.updateOn !== 'change') {
-            this.control.setValue(value);
             this.control.markAsTouched();
+            // with updateOn 'blur' strategy, the first change might not triggered within this cycle
+            // and therefore, potential validation errors may not be displayed
+            if (this.control.pristine && (this.control.value || value) && this.control.value !== value) {
+                this.control.markAsDirty();
+            }
+            this.control.setValue(value);
             this.control.updateValueAndValidity({ emitEvent: true });
         }
     }


### PR DESCRIPTION
When used with a formControl using updatOn 'blur', text-field components need an early markAsDirty when the component is blurred in order to display the first validation errors