### PR TITLE
Dropdown and Popup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.55.7 (2022-10-18)
+
+### Documentation improvements
+- **Dropdown**: [mpellerin42] 
+  - Fix and document multi-level dropdown demo (`keepOthersOpen` attribute was missing)
+  - Add popup usage section in dropdown usage
+  - Improve global look and feel of dropdown documentation page
+
 # 2.55.6 (2022-09-19)
 
 ### Bug fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.55.7 (2022-10-18)
+# 2.56.0 (2022-10-18)
+
+### Breaking Changes
+- **Popup directive**: [mpellerin42]
+  - rename `popupOnRight` attribute into `alignPopupOnLeft` to align the attribute name with its behavior 
 
 ### Documentation improvements
 - **Dropdown**: [mpellerin42] 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Popup directive**: [mpellerin42]
   - rename `popupOnRight` into `alignPopupOnLeft` to align the attribute name with its behavior
   - rename `popupMargin` into `popupVerticalOffset` to align the attribute name with its behavior
+  - implement `popupOnRight` with a behavior aligned to its name: when true the popup is positioned on the right of the directive element
 
 ### Documentation improvements
 - **Popup**: [mpellerin42]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - rename `popupOnRight` into `alignPopupOnLeft` to align the attribute name with its behavior
   - rename `popupMargin` into `popupVerticalOffset` to align the attribute name with its behavior
   - implement `popupOnRight` with a behavior aligned to its name: when true the popup is positioned on the right of the directive element
+  - CSS position is now fixed instead of absolute 
 
 ### Documentation improvements
 - **Popup**: [mpellerin42]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### Breaking Changes
 - **Popup directive**: [mpellerin42]
-  - rename `popupOnRight` attribute into `alignPopupOnLeft` to align the attribute name with its behavior 
+  - rename `popupOnRight` into `alignPopupOnLeft` to align the attribute name with its behavior
+  - rename `popupMargin` into `popupVerticalOffset` to align the attribute name with its behavior
 
 ### Documentation improvements
+- **Popup**: [mpellerin42]
+  - Add documentation for `popupOffset` attribute
 - **Dropdown**: [mpellerin42] 
   - Fix and document multi-level dropdown demo (`keepOthersOpen` attribute was missing)
   - Add popup usage section in dropdown usage

--- a/projects/demo/src/app/demo/demo.module.ts
+++ b/projects/demo/src/app/demo/demo.module.ts
@@ -137,6 +137,7 @@ import { ButtonDescriptionComponent } from './pages/button-page/button-descripti
 import { RadioPageComponent } from './pages/radio-page/radio-page.component';
 import { ConfirmationDialogDescriptionComponent } from './pages/confirmation-dialog-page/confirmation-dialog-description.component';
 import { ConfirmationDialogUsageComponent } from './pages/confirmation-dialog-page/confirmation-dialog-usage.component';
+import { PopupComponentUsageComponent } from './pages/popup-page/popup-component-usage/popup-component-usage.component';
 
 const COMPONENTS = [
     DemoComponent,
@@ -199,6 +200,7 @@ const COMPONENTS = [
     PaInputConfigComponent,
     ModalPageComponent,
     PalettePageComponent,
+    PopupComponentUsageComponent,
     PopupPageComponent,
     SelectPageComponent,
     SelectStandaloneExampleComponent,

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
@@ -9,7 +9,7 @@
             <code>PaDropdownModule</code> contains every thing you need to build your dropdowns:
         </p>
         <ul>
-            <li><code>DropdownComponent</code>: brings the popup behaviour and is mainly a wrapper for the list of options using the following components</li>
+            <li><code>DropdownComponent</code>: brings the popup behaviour and wraps the list of options using the following components</li>
             <li><code>OptionHeaderComponent</code>: header allowing to group options</li>
             <li><code>OptionComponent</code>: option item</li>
             <li><code>SeparatorComponent</code>: option separator</li>
@@ -76,7 +76,7 @@
                            (selectOption)="onLevel1Selection('sith')">Sith</pa-option>
             </pa-dropdown>
 
-            <pa-dropdown #level2>
+            <pa-dropdown #level2 keepOthersOpen>
                 <pa-option dontCloseOnSelect *ngFor="let option of level2Options">
                     <pa-checkbox>{{option.label}}</pa-checkbox>
                 </pa-option>
@@ -85,16 +85,30 @@
     </pa-demo-examples>
 
     <pa-demo-usage>
-        <h2><code>DropdownComponent</code></h2>
-        <p>Brings the popup behaviour and is mainly a wrapper for the list of options. It works with <code>ng-content</code>.</p>
+        <h2>DropdownComponent</h2>
+        <p>Dropdown component is mainly a wrapper (using <code>ng-content</code>) for the list of options to be displayed. It extends popup component adding the <code>role</code> attribute to it.</p>
+
+        <p>
+            Multi-level dropdown can be created by using the <code>companionElement</code> attribute on the first level dropdown
+            (targeting the 2nd level dropdown element), the <code>keepOthersOpen</code> attribute on the second level dropdown,
+            as well as <code>dontCloseOnSelect</code> attribute on options of both dropdowns.
+            See how in the Code section below.
+        </p>
 
         <h3>Inputs</h3>
         <dl>
             <dt>role</dt>
             <dd>listbox | menu <small>(default: menu)</small></dd>
         </dl>
+
         <br>
-        <h2><code>OptionComponent</code></h2>
+
+        <h2>PopupComponent</h2>
+        <p><code>DropdownComponent</code> extends <code>PopupComponent</code>, here are the Inputs and Outputs inherited from it:</p>
+        <pa-demo-popup-component-usage></pa-demo-popup-component-usage>
+
+        <br>
+        <h2>OptionComponent</h2>
         <h3>Inputs</h3>
         <dl>
             <dt>avatar</dt>
@@ -136,10 +150,10 @@
     </pa-demo-usage>
 
     <pa-demo-code>
-        <strong>Simple menu</strong>
+        <strong>Simple menu</strong>:
         <pre><code>{{codeExample}}</code></pre>
 
-        <strong>Multi-level dropdown</strong><br>
+        <p><strong>Multi-level dropdown</strong></p>
         Template:
         <pre><code>{{multiLevelTemplate}}</code></pre>
 

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
@@ -56,22 +56,25 @@
                 <pa-option icon="chevron-right"
                            iconOnRight
                            dontCloseOnSelect
-                           [popupPosition]="{position: 'relative', left: '100%', top: '4px'}"
+                           popupOnRight
                            [paPopup]="level2"
+                           [popupVerticalOffset]="-40"
                            [selected]="level1Open === 'jedi'"
                            (selectOption)="onLevel1Selection('jedi')">Jedi</pa-option>
                 <pa-option icon="chevron-right"
                            iconOnRight
                            dontCloseOnSelect
-                           [popupPosition]="{position: 'relative', left: '100%', top: '44px'}"
+                           popupOnRight
                            [paPopup]="level2"
+                           [popupVerticalOffset]="-40"
                            [selected]="level1Open === 'rebels'"
                            (selectOption)="onLevel1Selection('rebels')">Rebels</pa-option>
                 <pa-option icon="chevron-right"
                            iconOnRight
                            dontCloseOnSelect
-                           [popupPosition]="{position: 'relative', left: '100%', top: '84px'}"
+                           popupOnRight
                            [paPopup]="level2"
+                           [popupVerticalOffset]="-40"
                            [selected]="level1Open === 'sith'"
                            (selectOption)="onLevel1Selection('sith')">Sith</pa-option>
             </pa-dropdown>
@@ -88,12 +91,14 @@
         <h2>DropdownComponent</h2>
         <p>Dropdown component is mainly a wrapper (using <code>ng-content</code>) for the list of options to be displayed. It extends popup component adding the <code>role</code> attribute to it.</p>
 
-        <p>
-            Multi-level dropdown can be created by using the <code>companionElement</code> attribute on the first level dropdown
-            (targeting the 2nd level dropdown element), the <code>keepOthersOpen</code> attribute on the second level dropdown,
-            as well as <code>dontCloseOnSelect</code> attribute on options of both dropdowns.
-            See how in the Code section below.
-        </p>
+        <p>Multi-level dropdown can be created by using <small>(more details on the Code section below)</small>:</p>
+        <ul>
+            <li><code>companionElement</code> attribute on the first level dropdown (targeting the 2nd level dropdown element)</li>
+            <li><code>keepOthersOpen</code> attribute on the second level dropdown</li>
+            <li><code>paPopup</code> and <code>popupOnRight</code> on the options of the first level dropdown</li>
+            <li><code>dontCloseOnSelect</code> attribute on options of both dropdowns</li>
+            <li>optionally, you can adjust the position of the 2nd level dropdown with <code>popupVerticalOffset</code> on the options of the first level dropdown</li>
+        </ul>
 
         <h3>Inputs</h3>
         <dl>

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
@@ -37,22 +37,25 @@ export class DropdownPageComponent {
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               [popupPosition]="{position: 'relative', left: '100%', top: '4px'}"
+               popupOnRight
                [paPopup]="level2"
+               [popupVerticalOffset]="-40"
                [selected]="level1Open === 'jedi'"
                (selectOption)="onLevel1Selection('jedi')">Jedi</pa-option>
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               [popupPosition]="{position: 'relative', left: '100%', top: '44px'}"
+               popupOnRight
                [paPopup]="level2"
+               [popupVerticalOffset]="-40"
                [selected]="level1Open === 'rebels'"
                (selectOption)="onLevel1Selection('rebels')">Rebels</pa-option>
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               [popupPosition]="{position: 'relative', left: '100%', top: '84px'}"
+               popupOnRight
                [paPopup]="level2"
+               [popupVerticalOffset]="-40"
                [selected]="level1Open === 'sith'"
                (selectOption)="onLevel1Selection('sith')">Sith</pa-option>
 </pa-dropdown>

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
@@ -57,7 +57,7 @@ export class DropdownPageComponent {
                (selectOption)="onLevel1Selection('sith')">Sith</pa-option>
 </pa-dropdown>
 
-<pa-dropdown #level2>
+<pa-dropdown #level2 keepOthersOpen>
     <pa-option dontCloseOnSelect *ngFor="let option of level2Options">{{option.label}}</pa-option>
 </pa-dropdown>`;
     multiLevelScript = `
@@ -84,10 +84,10 @@ onLevel1Selection(selection: string) {
     }
 }`;
 
-    @ViewChild('level2', {read: ElementRef}) level2Element?: ElementRef;
+    @ViewChild('level2', { read: ElementRef }) level2Element?: ElementRef;
     @ViewChild('level2') level2Popup?: PopupComponent;
     level1Open = '';
-    level2Options: {label: string}[] = [];
+    level2Options: { label: string }[] = [];
 
     onSelect($event: MouseEvent | KeyboardEvent) {
         console.log(`Selected menu:`, $event);
@@ -95,16 +95,16 @@ onLevel1Selection(selection: string) {
 
     onLevel1Selection(selection: string) {
         this.level1Open = selection;
-        this.level2Popup?.close()
+        this.level2Popup?.close();
         switch (selection) {
             case 'jedi':
-                this.level2Options = [{label: 'Yoda'}, {label: 'Obiwan Kenobi'}, {label: 'Luke Skywalker'}];
+                this.level2Options = [{ label: 'Yoda' }, { label: 'Obiwan Kenobi' }, { label: 'Luke Skywalker' }];
                 break;
             case 'rebels':
-                this.level2Options = [{label: 'Leia Organa'}, {label: 'Han Solo'}, {label: 'Admiral Ackbar'}];
+                this.level2Options = [{ label: 'Leia Organa' }, { label: 'Han Solo' }, { label: 'Admiral Ackbar' }];
                 break;
             case 'sith':
-                this.level2Options = [{label: 'Sheev Palpatine'}, {label: 'Darth Vador'}, {label: 'Darth Maul'}];
+                this.level2Options = [{ label: 'Sheev Palpatine' }, { label: 'Darth Vador' }, { label: 'Darth Maul' }];
                 break;
             default:
                 this.level2Options = [];

--- a/projects/demo/src/app/demo/pages/popup-page/popup-component-usage/popup-component-usage.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-component-usage/popup-component-usage.component.html
@@ -1,0 +1,32 @@
+<h3>Inputs</h3>
+<dl>
+    <dt>companionElement</dt>
+    <dd>
+        When clicking on the companion element – which is outside the popup and must be an HTML element – the
+        popup won’t close. It offers external interactions (like filtering the popup content for example).
+        <small>(optional)</small> <br />When companionElement is an angular component, you must provide its
+        nativeElement, <em>eg.</em> <code>[companionElement]="somePaInput.element.nativeElement"</code>
+    </dd>
+
+    <dt>dontAdjustPosition</dt>
+    <dd>
+        Keep default popup position even if there is not enough space to display it entirely.
+        <small>(default: false)</small>
+    </dd>
+
+    <dt>id</dt>
+    <dd>Popup's id <small>(optional, an id will be generated if none is provided)</small></dd>
+
+    <dt>keepOthersOpen</dt>
+    <dd>Control if other popups should be closed when current one is opened. <small>(default: false)</small></dd>
+
+    <dt>stayVisible</dt>
+    <dd>Keep the popup visible when set to true <small>(default: false)</small></dd>
+</dl>
+<h3>Outputs</h3>
+<dl>
+    <dt>onClose</dt>
+    <dd>Event emitted whenever the popup is closed</dd>
+    <dt>onOpen</dt>
+    <dd>Event emitted whenever the popup is opened</dd>
+</dl>

--- a/projects/demo/src/app/demo/pages/popup-page/popup-component-usage/popup-component-usage.component.ts
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-component-usage/popup-component-usage.component.ts
@@ -1,0 +1,8 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+    selector: 'pa-demo-popup-component-usage',
+    templateUrl: './popup-component-usage.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PopupComponentUsageComponent {}

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
@@ -13,15 +13,13 @@
     </pa-demo-description>
 
     <pa-demo-examples>
-        <pa-button
-            [paPopup]="myPopup"
-            [popupOnRight]="popupOnRight"
-            [popupOnTop]="popupOnTop"
-            [sameWidth]="sameWidth"
-            #myPopupDirective="paPopupRef"
-            size="small"
-            >Open popup</pa-button
-        >
+        <pa-button [paPopup]="myPopup"
+                   [alignPopupOnLeft]="alignOnLeft"
+                   [popupOnTop]="popupOnTop"
+                   [sameWidth]="sameWidth"
+                   #myPopupDirective="paPopupRef"
+                   size="small"
+        >Open popup</pa-button>
         <pa-popup #myPopup>Popup content</pa-popup>
 
         <div>
@@ -33,7 +31,7 @@
     </pa-demo-examples>
     <pa-demo-configuration>
         <p>
-            <pa-checkbox id="popupOnRight" [(ngModel)]="popupOnRight">Open popup on right</pa-checkbox>
+            <pa-checkbox id="alignOnLeft" [(ngModel)]="alignOnLeft">Align popup on the left</pa-checkbox>
         </p>
         <p>
             <pa-checkbox id="popupOnTop" [(ngModel)]="popupOnTop">Open popup on top</pa-checkbox>
@@ -47,10 +45,14 @@
         <h2>PopupComponent</h2>
         <pa-demo-popup-component-usage></pa-demo-popup-component-usage>
 
-        <br />
+        <br/>
         <h2>PopupDirective</h2>
         <h3>Inputs</h3>
         <dl>
+            <dt>alignPopupOnLeft</dt>
+            <dd>Set the popup on the left of the element carrying the directive <small>(default: false, meaning the
+                popup is aligned on the right of the carrying directive by default)</small></dd>
+
             <dt>openOnly</dt>
             <dd>
                 Don't close popup when clicking on the element carrying the directive while the popup is visible.
@@ -66,11 +68,9 @@
             <dt>popupPosition</dt>
             <dd>
                 Position style to be used on the popup
-                <small>(optional: by default the popup is positioned on top of the element carrying the directive)</small>
+                <small>(optional: by default the popup is positioned on top of the element carrying the
+                    directive)</small>
             </dd>
-
-            <dt>popupOnRight</dt>
-            <dd>Set the popup on the right of the element carrying the directive <small>(default: false)</small></dd>
 
             <dt>popupOnTop</dt>
             <dd>Set the popup on the top of the element carrying the directive <small>(default: false)</small></dd>
@@ -85,7 +85,8 @@
 
         To open a popup programmatically, in your template add a reference to your popup directive:
         <pre><code>{{openProgrammaticallyTemplate}}</code></pre>
-        Then in your component, you can call <code style="display: inline; background: #fff;">toggle</code> method of your directive to open/close the popup:
+        Then in your component, you can call <code style="display: inline; background: #fff;">toggle</code> method of
+        your directive to open/close the popup:
         <pre><code>{{openProgrammaticallyComponent}}</code></pre>
     </pa-demo-code>
 </pa-demo-page>

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
@@ -75,8 +75,11 @@
                     directive)</small>
             </dd>
 
+            <dt>popupOnRight</dt>
+            <dd>Set the popup position to be on the right of the element carrying the directive <small>(default: false)</small></dd>
+
             <dt>popupOnTop</dt>
-            <dd>Set the popup on the top of the element carrying the directive <small>(default: false)</small></dd>
+            <dd>Set the popup position to be on top of the element carrying the directive <small>(default: false)</small></dd>
 
             <dt>sameWidth</dt>
             <dd>Set the popup width equals to the element carrying the directive <small>(default: false)</small></dd>

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
@@ -45,38 +45,7 @@
 
     <pa-demo-usage>
         <h2>PopupComponent</h2>
-        <h3>Inputs</h3>
-        <dl>
-            <dt>companionElement</dt>
-            <dd>
-                When clicking on the companion element – which is outside the popup and must be an HTML element – the
-                popup won’t close. It offers external interactions (like filtering the popup content for example).
-                <small>(optional)</small> <br />When companionElement is an angular component, you must provide its
-                nativeElement, <em>eg.</em> <code>[companionElement]="somePaInput.element.nativeElement"</code>
-            </dd>
-
-            <dt>dontAdjustPosition</dt>
-            <dd>
-                Keep default popup position even if there is not enough space to display it entirely.
-                <small>(default: false)</small>
-            </dd>
-
-            <dt>id</dt>
-            <dd>Popup's id <small>(optional, an id will be generated if none is provided)</small></dd>
-
-            <dt>keepOthersOpen</dt>
-            <dd>Control if other popups should be closed when current one is opened. <small>(default: false)</small></dd>
-
-            <dt>stayVisible</dt>
-            <dd>Keep the popup visible when set to true <small>(default: false)</small></dd>
-        </dl>
-        <h3>Outputs</h3>
-        <dl>
-            <dt>onClose</dt>
-            <dd>Event emitted whenever the popup is closed</dd>
-            <dt>onOpen</dt>
-            <dd>Event emitted whenever the popup is opened</dd>
-        </dl>
+        <pa-demo-popup-component-usage></pa-demo-popup-component-usage>
 
         <br />
         <h2>PopupDirective</h2>

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
@@ -65,6 +65,9 @@
             <dt>popupDisabled</dt>
             <dd>Don't open popup when clicking on the element carrying the directive</dd>
 
+            <dt>popupVerticalOffset</dt>
+            <dd>Vertical offset between the popup and its parent. <small>(default: 4px)</small></dd>
+
             <dt>popupPosition</dt>
             <dd>
                 Position style to be used on the popup

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.ts
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.ts
@@ -23,7 +23,7 @@ openProgrammatically(event: MouseEvent) {
 }
 `;
 
-    popupOnRight = false;
+    alignOnLeft = false;
     popupOnTop = false;
     sameWidth = false;
     @ViewChild('myPopupDirective') myPopupDirective?: PopupDirective;

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.55.6",
+    "version": "2.55.7",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.55.7",
+    "version": "2.56.0",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -17,7 +17,7 @@
          [attr.aria-label]="label"
          [attr.aria-describedby]="describedById"
          [paPopup]="optionsDropdown"
-         [popupMargin]="0"
+         [popupVerticalOffset]="0"
          [popupDisabled]="control.disabled || readonly"
          (cdkFocusChange)="onControlFocused($event)">
         <span class="pa-select-value"

--- a/projects/pastanaga-angular/src/lib/date-picker/date-picker.component.html
+++ b/projects/pastanaga-angular/src/lib/date-picker/date-picker.component.html
@@ -1,4 +1,4 @@
-<div [paPopup]="popup" popupOnRight="true" #popupRef="paPopupRef">
+<div [paPopup]="popup" alignPopupOnLeft="true" #popupRef="paPopupRef">
     <pa-input
         #input
         size="small"

--- a/projects/pastanaga-angular/src/lib/popup/popover/popover.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popover/popover.directive.ts
@@ -4,7 +4,7 @@ import { filter, map, take, takeUntil } from 'rxjs/operators';
 import { WINDOW } from '@ng-web-apis/common';
 import { PopoverComponent } from './popover.component';
 import { PopupDirective } from '../popup.directive';
-import { BreakpointObserver, ViewportMode } from '../../breakpoint-observer/breakpoint.observer';
+import { BreakpointObserver, ViewportMode } from '../../breakpoint-observer';
 import { PositionStyle } from '../../common';
 
 @Directive({

--- a/projects/pastanaga-angular/src/lib/popup/popup.component.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.component.ts
@@ -17,7 +17,7 @@ import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
 let nextId = 0;
-export const MARGIN = 4;
+export const POPUP_OFFSET = 4;
 
 @Component({
     selector: 'pa-popup',
@@ -164,7 +164,7 @@ export class PopupComponent implements OnInit, OnDestroy {
         if (!this._dontAdjustPosition) {
             isAdjusted = this._adjustPosition(element, rect, diffX, diffY);
         } else if (this._adjustHeight && diffY > 0) {
-            element.style.maxHeight = `${this._originalHeight - diffY - MARGIN}px`;
+            element.style.maxHeight = `${this._originalHeight - diffY - POPUP_OFFSET}px`;
             isAdjusted = true;
         }
         if (isAdjusted) {
@@ -185,7 +185,7 @@ export class PopupComponent implements OnInit, OnDestroy {
             const currentTop = element.style.top || '';
             if (currentTop.endsWith('px') && parseInt(currentTop.slice(0, -2), 10) > this._originalHeight) {
                 // enough space above, we display the dropdown on top
-                element.style.top = `calc(${currentTop} - ${this._originalHeight}px - ${MARGIN * 2}px)`;
+                element.style.top = `calc(${currentTop} - ${this._originalHeight}px - ${POPUP_OFFSET * 2}px)`;
                 return true;
             } else if (!!currentTop) {
                 // not enough space, we just align the dropdown bottom with the parent bottom

--- a/projects/pastanaga-angular/src/lib/popup/popup.component.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.component.ts
@@ -130,6 +130,11 @@ export class PopupComponent implements OnInit, OnDestroy {
         this.adjustPosition();
     }
 
+    updatePosition(style: PositionStyle) {
+        this.style = style;
+        markForCheck(this.cdr);
+    }
+
     private adjustPosition() {
         window.setTimeout(() => {
             if ((!this.dontAdjustPosition || this.adjustHeight) && !this.adjust()) {

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, HostListener, Input, OnInit, Renderer2 } from '@angular/core';
 import { getPositionedParent, PositionStyle } from '../common';
-import { MARGIN, PopupComponent } from './popup.component';
+import { POPUP_OFFSET, PopupComponent } from './popup.component';
 import { coerceBooleanProperty, coerceNumberProperty } from '@angular/cdk/coercion';
 import { PopupService } from './popup.service';
 
@@ -11,8 +11,12 @@ import { PopupService } from './popup.service';
 export class PopupDirective implements OnInit {
     @Input() paPopup?: PopupComponent | null;
     @Input() popupPosition?: PositionStyle;
-    @Input() set popupMargin(value: number) {
-        this._margin = coerceNumberProperty(value);
+    @Input()
+    set popupVerticalOffset(value: number) {
+        this._popupVerticalOffset = coerceNumberProperty(value);
+    }
+    get popupVerticalOffset() {
+        return this._popupVerticalOffset;
     }
     @Input()
     get alignPopupOnLeft(): boolean {
@@ -57,7 +61,7 @@ export class PopupDirective implements OnInit {
     private _alignPopupOnLeft = false;
     private _popupOnTop = false;
     private _sameWidth = false;
-    private _margin = MARGIN;
+    private _popupVerticalOffset = POPUP_OFFSET;
 
     constructor(private element: ElementRef, private service: PopupService, private renderer: Renderer2) {}
 
@@ -103,8 +107,8 @@ export class PopupDirective implements OnInit {
 
         const position: PositionStyle = {
             position: 'absolute',
-            top: !this.popupOnTop ? top + this._margin + 'px' : undefined,
-            bottom: this.popupOnTop ? bottom + this._margin + 'px' : undefined,
+            top: !this.popupOnTop ? top + this.popupVerticalOffset + 'px' : undefined,
+            bottom: this.popupOnTop ? bottom + this.popupVerticalOffset + 'px' : undefined,
             width: this._sameWidth ? rect.right - rect.left + 'px' : undefined,
         };
 

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -15,11 +15,11 @@ export class PopupDirective implements OnInit {
         this._margin = coerceNumberProperty(value);
     }
     @Input()
-    get popupOnRight(): boolean {
-        return this._popupOnRight;
+    get alignPopupOnLeft(): boolean {
+        return this._alignPopupOnLeft;
     }
-    set popupOnRight(value: any) {
-        this._popupOnRight = coerceBooleanProperty(value);
+    set alignPopupOnLeft(value: any) {
+        this._alignPopupOnLeft = coerceBooleanProperty(value);
     }
     @Input()
     get popupOnTop(): boolean {
@@ -54,7 +54,7 @@ export class PopupDirective implements OnInit {
     private _disabled = false;
     private _openOnly = false;
 
-    private _popupOnRight = false;
+    private _alignPopupOnLeft = false;
     private _popupOnTop = false;
     private _sameWidth = false;
     private _margin = MARGIN;
@@ -108,7 +108,7 @@ export class PopupDirective implements OnInit {
             width: this._sameWidth ? rect.right - rect.left + 'px' : undefined,
         };
 
-        if (this._popupOnRight) {
+        if (this._alignPopupOnLeft) {
             position.left = Math.min(rect.left - rootRect.left, window.innerWidth - 240) + 'px';
         } else {
             position.right = Math.min(rootRect.right - rect.right, window.innerWidth - 240) + 'px';


### PR DESCRIPTION
### Breaking Changes
- **Popup directive**: 
  - rename `popupOnRight` into `alignPopupOnLeft` to align the attribute name with its behavior
  - rename `popupMargin` into `popupVerticalOffset` to align the attribute name with its behavior
  - implement `popupOnRight` with a behavior aligned to its name: when true the popup is positioned on the right of the directive element
  - CSS position is now fixed instead of absolute 

### Documentation improvements
- **Popup**: 
  - Add documentation for `popupOffset` attribute
- **Dropdown**: 
  - Fix and document multi-level dropdown demo (`keepOthersOpen` attribute was missing)
  - Add popup usage section in dropdown usage
  - Improve global look and feel of dropdown documentation page