### PR TITLE
Text field improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# 2.57.3 (unreleased)
+# 2.58.0 (2022-12-06)
+
+### Breaking changes
+- Text fields: [mpellerin42]
+  - No more background color on text fields by default
+  - Improve text field border so label doesn't require a background color and border keep space for the label on active and focus states
+  - Replace border-text-field tokens by border-color-text-field token
+  - Text field borders management:
+      - No more borders on input themselves
+      - Add a new `pa-field-container` carrying the classes for all the states (error, disabled, readonly, focus, has content)
+      - No more background required on labels to have them displayed over the top border
+  - Replace border-text-field tokens by border-color-text-field tokens
+  - Use this new style structure on all our fields (input, textarea, select)
+  - New `TextFieldDirective` managing label width as well as focus and content states
+
+### Improvements
+- Add autofilled input example [mpellerin42]
 
 ### Dependencies
 - Bumps loader-utils from 2.0.2 to 2.0.3 [Dependabot]

--- a/projects/demo/src/app/demo/pages/input-page/input-page.component.html
+++ b/projects/demo/src/app/demo/pages/input-page/input-page.component.html
@@ -7,14 +7,18 @@
     </pa-demo-description>
 
     <pa-demo-examples>
-        <p>The following input demonstrates error state: type a character and delete it.</p>
+        <p><strong>Error state: type a character and delete it.</strong></p>
         <pa-input [(ngModel)]="model"
-                  name="selectExample"
+                  name="inputExample"
                   required
                   placeholder="Placeholder"
                   help="Display the error state by typing something and deleting it"
                   [errorMessages]="{required: 'Error message: required'}">Required input</pa-input>
 
+        <p><strong>Autofill: click and select browser's suggestion</strong></p>
+        <pa-input name="email"
+                  id="email"
+                  type="text">Autofilled input</pa-input>
         <pa-tabs>
             <pa-tab (click)="selectedTab = 'standalone'"
                     [active]="selectedTab === 'standalone'">Standalone</pa-tab>

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.57.2",
+    "version": "2.58.0",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
@@ -1,31 +1,39 @@
 <div class="pa-field"
-     [class.pa-field-error]="control.dirty && control.invalid">
-    <input #htmlInput
-           class="pa-field-control"
-           [class.pa-field-control-filled]="isFilled"
-           [class.pa-field-control-icon]="!!icon"
-           [class.pa-icon-on-right]="iconOnRight"
-           [formControl]="control"
-           [id]="id"
-           [attr.name]="name"
-           [type]="type"
-           [attr.maxlength]="maxlength"
-           [attr.aria-describedby]="describedById"
-           [attr.placeholder]="placeholder"
-           [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
-           [attr.autocapitalize]="autocapitalize || undefined"
-           [readonly]="readonly"
-           [paInputFormatter]="sanitizeHtmlTags"
-           (blur)="onBlur()"
-           (keyup)="onKeyUp($event)"
-           (focus)="onFocus($event)"
-    >
-    <label class="pa-field-label"
-           [class.pa-field-label-icon]="!!icon"
-           [class.pa-icon-on-right]="iconOnRight"
-           [for]="id">
-        <ng-content></ng-content>
-    </label>
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-focus]="hasFocus"
+         [class.pa-content]="hasContent"
+         [class.pa-disabled]="disabled || readonly"
+         [class.pa-readonly]="readonly"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <input #htmlInput
+               class="pa-field-control"
+               [class.pa-field-control-filled]="isFilled"
+               [class.pa-field-control-icon]="!!icon"
+               [class.pa-icon-on-right]="iconOnRight"
+               [formControl]="control"
+               [id]="id"
+               [attr.name]="name"
+               [type]="type"
+               [attr.maxlength]="maxlength"
+               [attr.aria-describedby]="describedById"
+               [attr.placeholder]="placeholder"
+               [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
+               [attr.autocapitalize]="autocapitalize || undefined"
+               [readonly]="readonly"
+               [paInputFormatter]="sanitizeHtmlTags"
+               (focus)="onFocus($event)"
+               (blur)="onBlur()"
+               (keyup)="onKeyUp($event)"
+        >
+
+        <label class="pa-field-label"
+               [class.pa-field-label-icon]="!!icon"
+               [class.pa-icon-on-right]="iconOnRight"
+               [for]="id">
+            <ng-content></ng-content>
+        </label>
+    </div>
 
     <pa-icon *ngIf="!!icon" [name]="icon" [class.pa-icon-on-right]="iconOnRight"></pa-icon>
 

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -1,39 +1,44 @@
 <div class="pa-field pa-select"
-     [class.pa-field-readonly]="readonly"
-     [class.pa-field-disabled]="control.disabled"
-     [class.pa-field-error]="control.dirty && control.invalid">
-    <div #selectInput
-         class="select-input pa-field-control"
-         paFocusable
-         cdkMonitorElementFocus
-         sameWidth
-         [class.pa-field-control-filled]="hasValue || isOpened"
-         [class.read-only]="readonly"
-         [class.disabled]="control.disabled"
-         [class.dim]="dim"
-         [class.expanded]="isOpened"
-         [id]="id"
-         [attr.name]="name"
-         [attr.aria-label]="label"
-         [attr.aria-describedby]="describedById"
-         [paPopup]="optionsDropdown"
-         [popupVerticalOffset]="0"
-         [popupDisabled]="control.disabled || readonly"
-         (cdkFocusChange)="onControlFocused($event)">
-        <span class="pa-select-value"
-              [class.placeholder]="!hasValue"
-              [class.active]="isOpened"
-        >{{displayedValue}}</span>
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-dim]="dim"
+         [class.pa-focus]="isOpened"
+         [class.pa-content]="hasContent"
+         [class.pa-readonly]="readonly"
+         [class.pa-disabled]="control.disabled"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <div #selectInput
+             class="select-input pa-field-control"
+             tabindex="0"
+             cdkMonitorElementFocus
+             sameWidth
+             [class.pa-field-control-filled]="hasValue || isOpened"
+             [class.read-only]="readonly"
+             [class.disabled]="control.disabled"
+             [class.expanded]="isOpened"
+             [id]="id"
+             [attr.name]="name"
+             [attr.aria-label]="label"
+             [attr.aria-describedby]="describedById"
+             [paPopup]="optionsDropdown"
+             [popupVerticalOffset]="0"
+             [popupDisabled]="control.disabled || readonly"
+             (cdkFocusChange)="onControlFocused($event)">
+            <span class="pa-select-value"
+                  [class.placeholder]="!hasValue"
+                  [class.active]="isOpened"
+            >{{displayedValue}}</span>
+        </div>
+
+        <label class="pa-field-label"
+               [class.pa-sr-only]="dim && (hasValue || isOpened)"
+               [for]="id">{{label}}</label>
+
+        <pa-icon class="pa-select-chevron"
+                 name="chevron-down"
+                 [class.opened]="isOpened"
+                 (click)="toggleDropdown()"></pa-icon>
     </div>
-
-    <label class="pa-field-label"
-           [class.pa-sr-only]="dim && (hasValue || isOpened)"
-           [for]="id">{{label}}</label>
-
-    <pa-icon class="pa-select-chevron"
-             name="chevron-down"
-             [class.opened]="isOpened"
-             (click)="toggleDropdown()"></pa-icon>
 
     <pa-form-field-hint
         [id]="describedById"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
@@ -4,15 +4,15 @@ import { SelectComponent } from './select.component';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { FormFieldHintComponent, PaFormControlDirective } from '../../form-field';
 import { MockComponent, MockModule, MockPipe, MockProvider, ngMocks } from 'ng-mocks';
-import { PaDropdownModule, DropdownComponent } from '../../../dropdown';
+import { DropdownComponent, PaDropdownModule } from '../../../dropdown';
 import { PaPopupModule } from '../../../popup';
 import { SelectOptionsComponent } from './select-options/select-options.component';
 import { PaIconModule } from '../../../icon';
-import { fakeAsync, discardPeriodicTasks, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { OptionHeaderModel, OptionModel, OptionSeparator } from '../../control.model';
 import { SvgIconRegistryService } from 'angular-svg-icon';
 import { A11yModule, CdkMonitorFocus } from '@angular/cdk/a11y';
-import { PA_LANG, PA_TRANSLATIONS, TranslatePipe, PaTranslateModule } from '../../../translate';
+import { PA_LANG, PA_TRANSLATIONS, PaTranslateModule, TranslatePipe } from '../../../translate';
 
 @Component({ template: '' })
 class TestComponent {
@@ -228,21 +228,21 @@ describe('SelectComponent', () => {
 
     it('should apply disabled in standalone', () => {
         initWithTemplate(`<pa-select [value]="value" [disabled]="disabled">${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-disabled')).toEqual(null);
+        expect(spectator.query('.pa-disabled')).toEqual(null);
         host.disabled = true;
         spectator.detectChanges();
         expect(component.control.disabled).toEqual(true);
-        expect(spectator.query('.pa-field-disabled')).toBeTruthy();
+        expect(spectator.query('.pa-disabled')).toBeTruthy();
     });
 
     it('should apply disabled in formGroup', () => {
         initWithTemplate(
             `<form [formGroup]="formGroup"><pa-select formControlName="control">${optionsInTemplate}</pa-select></form>`,
         );
-        expect(spectator.query('.pa-field-disabled')).toEqual(null);
+        expect(spectator.query('.pa-disabled')).toEqual(null);
         host.formGroup.disable();
         expect(component.control.disabled).toEqual(true);
-        expect(spectator.query('.pa-field-disabled')).toBeTruthy();
+        expect(spectator.query('.pa-disabled')).toBeTruthy();
         // value is not updated
         whenFirstOptionClicked();
         expect(component.control.value).toEqual(null);
@@ -250,10 +250,10 @@ describe('SelectComponent', () => {
 
     it('should apply readonly', () => {
         initWithTemplate(`<pa-select [value]="value" [readonly]="readonly">${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-readonly')).toEqual(null);
+        expect(spectator.query('.pa-readonly')).toEqual(null);
         host.readonly = true;
         spectator.detectChanges();
-        expect(spectator.query('.pa-field-readonly')).toBeTruthy();
+        expect(spectator.query('.pa-readonly')).toBeTruthy();
         // value is not updated
         whenFirstOptionClicked();
         expect(component.control.value).toEqual(null);
@@ -377,7 +377,7 @@ describe('SelectComponent', () => {
 
     it('should render in dim mode', fakeAsync(() => {
         initWithTemplate(`<pa-select label="my field" dim>${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-control.dim')).toBeTruthy();
+        expect(spectator.query('.pa-field-container.pa-dim')).toBeTruthy();
         whenFirstOptionClicked();
         expect(spectator.query('label.pa-sr-only')).toBeTruthy();
         discardPeriodicTasks();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.ts
@@ -25,8 +25,8 @@ import { detectChanges, isVisibleInViewport, markForCheck } from '../../../commo
 import { fromEvent, Subject } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { PaFormControlDirective } from '../../form-field';
 import { IErrorMessages } from '../../form-field.model';
+import { TextFieldDirective } from '../text-field.directive';
 
 type OptionType = OptionModel | OptionSeparator | OptionHeaderModel;
 
@@ -35,18 +35,13 @@ type OptionType = OptionModel | OptionSeparator | OptionHeaderModel;
     templateUrl: './select.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SelectComponent extends PaFormControlDirective implements OnChanges, AfterViewInit, OnDestroy {
+export class SelectComponent extends TextFieldDirective implements OnChanges, AfterViewInit, OnDestroy {
     @Input() label = '';
     @Input() placeholder?: string;
 
     @Input() set options(values: OptionType[]) {
         this.dropDownModels = !!values ? values : [];
         this._updateDisplayedValue(this.control.value);
-    }
-
-    @Input() set hasFocus(value: any) {
-        this._hasFocus = coerceBooleanProperty(value);
-        this._focusInput();
     }
 
     @Input() adjustHeight = false;
@@ -80,7 +75,6 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
     displayedValue?: string;
     private optionsClosed$ = new Subject<void>();
     private contentOptionsChanged$ = new Subject<void>();
-    private _hasFocus = false;
     private _dim = false;
 
     protected _terminator = new Subject<void>();
@@ -110,10 +104,12 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
         }
     }
 
-    ngAfterViewInit(): void {
+    override ngAfterViewInit(): void {
+        super.ngAfterViewInit();
+
         this._handleNgContent();
         this._checkDescribedBy();
-        this._focusInput();
+        this.focusInput();
         this._updateDisplayedValue(this.control.value);
         // valueChanges may be triggered by an update value and validity...
         // we don't want to recompute the displayed option label in that case
@@ -182,8 +178,8 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
         }
     }
 
-    private _focusInput() {
-        if (this._hasFocus && this.isActive) {
+    override focusInput() {
+        if (this.hasFocus && this.isActive) {
             this._openOptionDropDown();
             if (!isVisibleInViewport(this.selectInput?.nativeElement)) {
                 this.selectInput?.nativeElement.scrollIntoView();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
@@ -1,0 +1,47 @@
+import { PaFormControlDirective } from '../form-field';
+import { AfterViewInit, Directive, Input } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+
+@Directive({
+    selector: '[paTextField]',
+})
+export class TextFieldDirective extends PaFormControlDirective implements AfterViewInit {
+    @Input()
+    set hasFocus(value: any) {
+        this._hasFocus = coerceBooleanProperty(value);
+        this.focusInput();
+    }
+    get hasFocus() {
+        return this._hasFocus;
+    }
+
+    private _hasFocus = false;
+    private _labelWidth?: number;
+
+    get hasContent() {
+        return this.control.value?.length > 0;
+    }
+
+    get labelWidth() {
+        return `${this._labelWidth}px`;
+    }
+
+    ngAfterViewInit() {
+        const label = this.element.nativeElement.querySelector('.pa-field-label');
+        if (label) {
+            this._labelWidth = label.getBoundingClientRect().width;
+        }
+    }
+
+    onFocus(event: any) {
+        this._hasFocus = true;
+    }
+
+    onBlur() {
+        this._hasFocus = false;
+    }
+
+    focusInput() {
+        // To be overridden
+    }
+}

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.module.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.module.ts
@@ -12,6 +12,7 @@ import { SelectComponent, SelectOptionsComponent } from './select';
 import { PaTextareaAutoHeightDirective, TextareaComponent } from './textarea';
 import { NativeTextFieldDirective } from './native-text-field.directive';
 import { PaDropdownModule, OptionComponent, OptionHeaderComponent, SeparatorComponent } from '../../dropdown';
+import { TextFieldDirective } from './text-field.directive';
 
 @NgModule({
     declarations: [
@@ -22,6 +23,7 @@ import { PaDropdownModule, OptionComponent, OptionHeaderComponent, SeparatorComp
         TextareaComponent,
         NativeTextFieldDirective,
         PaTextareaAutoHeightDirective,
+        TextFieldDirective,
     ],
     imports: [
         CommonModule,

--- a/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
@@ -1,27 +1,35 @@
-<div class="pa-field" [class.pa-field-error]="control.dirty && control.invalid">
-    <textarea #htmlInput
-              class="pa-field-control pa-field-textarea"
-              [class.pa-field-control-filled]="isFilled"
-              [class.pa-text-area-resizable]="resizable"
-              [formControl]="control"
-              [id]="id"
-              [attr.name]="name"
-              [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
-              [attr.placeholder]="placeholder"
-              [attr.maxlength]="maxlength"
-              [attr.aria-describedby]="describedById"
-              [readonly]="readonly"
-              [paTextareaAutoHeight]="autoHeight"
-              [paTextareaMaxHeight]="autoMaxHeight"
-              [attr.rows]="rows"
-              [paInputFormatter]="sanitizeHtmlTags"
-              (blur)="onBlur()"
-              (keyup)="onKeyUp($event)"
-              (focus)="onFocus($event)"
-    ></textarea>
-    <label class="pa-field-label" [for]="id" aria-hidden="true">
-        <ng-content></ng-content>
-    </label>
+<div class="pa-field"
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-focus]="hasFocus"
+         [class.pa-content]="hasContent"
+         [class.pa-disabled]="disabled || readonly"
+         [class.pa-readonly]="readonly"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <textarea #htmlInput
+                  class="pa-field-control pa-field-textarea"
+                  [class.pa-field-control-filled]="isFilled"
+                  [class.pa-text-area-resizable]="resizable"
+                  [formControl]="control"
+                  [id]="id"
+                  [attr.name]="name"
+                  [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
+                  [attr.placeholder]="placeholder"
+                  [attr.maxlength]="maxlength"
+                  [attr.aria-describedby]="describedById"
+                  [readonly]="readonly"
+                  [paTextareaAutoHeight]="autoHeight"
+                  [paTextareaMaxHeight]="autoMaxHeight"
+                  [attr.rows]="rows"
+                  [paInputFormatter]="sanitizeHtmlTags"
+                  (blur)="onBlur()"
+                  (keyup)="onKeyUp($event)"
+                  (focus)="onFocus($event)"
+        ></textarea>
+        <label class="pa-field-label" [for]="id" aria-hidden="true">
+            <ng-content></ng-content>
+        </label>
+    </div>
 
     <pa-form-field-hint
         [id]="describedById"

--- a/projects/pastanaga-angular/src/styles/_checkbox.scss
+++ b/projects/pastanaga-angular/src/styles/_checkbox.scss
@@ -97,16 +97,16 @@
         }
 
         .pa-toggle-control {
-            border: $border-field-error;
+            border-color: $border-color-field-error;
 
             &:not(:disabled) {
                 &:hover {
-                    border: $border-field-error-hover;
+                    border-color: $border-color-field-error;
                 }
 
                 &:focus,
                 &:active {
-                    border: $border-field-error-active;
+                    border-color: $border-color-field-error;
 
                     & ~ .pa-toggle-label {
                         color: $color-text-field-label-error;

--- a/projects/pastanaga-angular/src/styles/_select.scss
+++ b/projects/pastanaga-angular/src/styles/_select.scss
@@ -30,30 +30,30 @@
         right: $icon-right-padding;
         top: rhythm(1.5);
         width: $icon-width;
+
         &.opened {
             transform: rotate(180deg);
         }
     }
-    &.pa-field-disabled {
-        color: $color-text-field-control-disabled;
-        .pa-select-chevron {
-            cursor: default;
+
+    .pa-field-container {
+        &.pa-disabled {
+            color: $color-text-field-control-disabled;
+            .pa-select-chevron {
+                color: $color-text-field-control-disabled;
+            }
+        }
+        &.pa-readonly .pa-select-chevron {
+            color: $color-text-field-control-disabled;
+        }
+        &:not(.pa-disabled):not(.pa-readonly) {
+            cursor: pointer;
         }
     }
-    &.pa-field-readonly {
-        .pa-select-chevron {
-            cursor: default;
-        }
-    }
+
     .pa-field-control {
         padding-right: calc(#{$icon-width + $icon-right-padding});
         width: 100%;
-        cursor: pointer;
-
-        &.pa-keyboard-focus {
-            border: $border-field-autofilled;
-            box-shadow: none;
-        }
     }
     .pa-field-label {
         white-space: nowrap;
@@ -61,54 +61,25 @@
         text-overflow: ellipsis;
         max-width: calc(100% - #{$padding-field-control-left + $icon-width + $icon-right-padding});
     }
-}
 
-.pa-field.pa-select:not(.pa-field-error) {
-    .pa-field-control:read-only {
-        border: $border-field-regular;
+    .pa-dim,
+    .pa-field-container.pa-content.pa-dim {
+        border: 1px solid transparent;
 
-        &:not(.disabled):not(.read-only) {
-            &:hover {
-                border: $border-field-regular-hover;
-                margin: 0;
-            }
-            &:focus,
-            &:active,
-            &.expanded {
-                border: $border-field-regular-active;
-                margin: 0;
-
-                &::placeholder {
-                    opacity: 1;
-                    transition: all 1s ease;
-                }
-
-                &~.pa-field-label {
-                    color: $color-text-field-label-regular-active;
-                }
-            }
+        &::after,
+        &::before {
+            display: none;
         }
-        &.dim:not(:hover):not(:focus):not(:active):not(.expanded) {
-            border-color: transparent;
-            background-color: transparent;
+        &.pa-focus {
+            border: 1px solid $border-color-field-active;
         }
-        &.disabled:not(.dim) {
-            border: $border-field-disabled;
-            color: $color-text-field-control-disabled;
-
-            &~.pa-field-label {
-                color: $color-text-field-label-disabled;
-            }
+        &:not(.pa-focus):not(.pa-disabled):hover {
+            border: 1px solid $border-color-field-hover;
         }
-        &.read-only:not(.dim) {
-            border: $border-field-readonly;
+        &.pa-disabled,
+        &.pa-readonly {
+            border: 1px solid transparent;
         }
-    }
-}
-.pa-field.pa-select.pa-field-error {
-    .pa-field-control:not(.pa-field-control-filled) + .pa-field-label {
-        color: $color-text-field-label-regular;
-        background: $color-background-field-error;
     }
 }
 

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -1,19 +1,5 @@
 @import "variables";
 
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-textarea:-webkit-autofill,
-textarea:-webkit-autofill:hover,
-textarea:-webkit-autofill:focus,
-select:-webkit-autofill,
-select:-webkit-autofill:hover,
-select:-webkit-autofill:focus {
-    border: $border-field-autofilled;
-    -webkit-text-fill-color: inherit;
-    -webkit-box-shadow: 0 0 0 0 $color-background-field-autofilled inset;
-}
-
 .pa-field {
     $icon-width: rhythm(3);
 
@@ -36,25 +22,155 @@ select:-webkit-autofill:focus {
         }
     }
 
-    .pa-field-label {
-        position: absolute;
-        font-size: $font-size-field-control;
-        line-height: $line-height-field-control;
-        font-weight: $font-weight-label;
-        background: $color-background-field-regular;
-        color: $color-text-field-label-regular;
-        left: $padding-field-control-left;
-        top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
-        max-width: calc(100% - #{$padding-field-control-left * 2});
-        pointer-events: none;
-        transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
-        transform-origin: 0 0;
-
-        &.pa-field-label-icon:not(.pa-icon-on-right) {
-            left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+    .pa-field-container {
+        border: 1px solid $border-color-field-regular;
+        border-radius: $border-radius-field;
+        &::after,
+        &::before {
+            content: '';
+            height: 1px;
+            position: absolute;
+            top: 0;
+            z-index: 1;
         }
-        &.pa-field-label-icon.pa-icon-on-right {
-            max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
+
+        &::before {
+            left: 0;
+            width: rhythm(1);
+        }
+
+        &::after {
+            left: calc(var(--label-width) * #{$scale-text-field-label} + #{$padding-field-control-left}*2);
+            right: 1px;
+        }
+
+        &:hover {
+            border-color: $border-color-field-hover;
+        }
+
+        &:focus,
+        &:active,
+        &.pa-content,
+        &.pa-focus {
+            border-top: none;
+        }
+        &:focus,
+        &:active,
+        &.pa-focus {
+            border-color: $border-color-field-active;
+        }
+        &.pa-content {
+            border-top: none;
+
+            &::after,
+            &::before {
+                background: $border-color-field-regular;
+            }
+            &:not(.pa-focus):not(.pa-disabled):not(.pa-readonly):hover {
+                &::after,
+                &::before {
+                    background: $border-color-field-hover;
+                }
+            }
+        }
+
+        &:not(.pa-disabled):not(.pa-readonly):not(.pa-field-error).pa-focus {
+            &::after,
+            &::before {
+                background: $border-color-field-active;
+            }
+            .pa-field-label {
+                color: $color-text-field-label-regular-active;
+            }
+        }
+
+        &.pa-disabled {
+            border-color: $border-color-field-disabled;
+
+            &::after,
+            &::before {
+                background: $border-color-field-disabled;
+            }
+            .pa-field-label {
+                color: $color-text-field-label-disabled;
+            }
+        }
+        &.pa-readonly {
+            .pa-field-label {
+                color: $color-text-field-label-disabled;
+            }
+
+            border-color: $border-color-field-readonly;
+            border-style: dashed;
+            &.pa-content {
+                border-top: none;
+
+                &::after,
+                &::before {
+                    // Not using rhythm here because we want to mimic browser's `border-style: dashed` property
+                    background: repeating-linear-gradient(
+                            90deg,
+                            $border-color-field-readonly,
+                            $border-color-field-readonly 3px,
+                            transparent 3px,
+                            transparent 6px
+                    );
+                }
+            }
+            &:not(.pa-content) {
+                &::after,
+                &::before {
+                    display: none;
+                }
+            }
+        }
+        &.pa-field-error {
+            &:not(.pa-disabled):not(.pa-readonly) {
+                border-color: $border-color-field-error;
+
+                &::after,
+                &::before {
+                    background: $border-color-field-error;
+                }
+                &:hover {
+                    border-color: $border-color-field-error;
+                }
+                &:focus,
+                &:active,
+                &.pa-content,
+                &.pa-focus {
+                    border-color: $border-color-field-error;
+                }
+            }
+            .pa-field-label {
+                color: $color-text-field-label-error;
+            }
+
+            .pa-field-control {
+                background: $color-background-field-error;
+                caret-color: $color-caret-field-control-error;
+            }
+        }
+
+        .pa-field-label {
+            position: absolute;
+            font-size: $font-size-field-control;
+            line-height: $line-height-field-control;
+            font-weight: $font-weight-label;
+            color: $color-text-field-label-regular;
+            left: $padding-field-control-left;
+            top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
+            max-width: calc(100% - #{$padding-field-control-left * 2});
+            pointer-events: none;
+            transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
+            transform-origin: 0 0;
+
+            &.pa-field-label-icon:not(.pa-icon-on-right) {
+                left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+            }
+            &.pa-field-label-icon.pa-icon-on-right {
+                max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
+            }
         }
     }
 
@@ -64,8 +180,7 @@ select:-webkit-autofill:focus {
         background: $color-background-field-regular;
         color: $color-text-field-control-regular;
         caret-color: $color-caret-field-control-active;
-        border: $border-field-regular;
-        border-radius: $border-radius-field;
+        border: none;
         padding: $padding-field-control-top $padding-field-control-left;
         outline: none;
         margin: $border-width-active - $border-width-regular;
@@ -85,92 +200,30 @@ select:-webkit-autofill:focus {
         }
 
         &:not(:disabled):not(:read-only) {
-            &:hover {
-                border: $border-field-regular-hover;
-                margin: 0;
-            }
-
             &:focus,
             &:active {
-                border: $border-field-regular-active;
-                margin: 0;
-
                 &::placeholder {
                     opacity: 1;
                     transition: all 1s ease;
-                }
-
-                & ~ .pa-field-label {
-                    color: $color-text-field-label-regular-active;
                 }
             }
         }
 
         &.pa-field-control-filled,
-        &.cdk-text-field-autofilled,
         &:not(:disabled):not(:read-only):focus,
         &:not(:disabled):not(:read-only):active {
             & ~ .pa-field-label {
-                transform: scale(.8) translateY(-#{rhythm(4)}) translateX(-#{rhythm(.5)});
+                transform: scale(#{$scale-text-field-label}) translateY(-#{rhythm(3.5)}) translateX(-#{rhythm(.5)});
                 padding: 0 rhythm(1);
 
                 &.pa-field-label-icon:not(.pa-icon-on-right) {
-                    transform: scale(.8) translateY(-#{rhythm(4)}) translateX(calc(-#{rhythm(.5)} - #{$icon-width} - #{$padding-field-control-left * 2}));
+                    transform: scale(#{$scale-text-field-label}) translateY(-#{rhythm(3.5)}) translateX(calc(-#{rhythm(.5)} - #{$icon-width} - #{$padding-field-control-left * 2}));
                 }
             }
-        }
-
-        &.cdk-text-field-autofilled:not(:disabled):not(:read-only) {
-            & ~ .pa-field-label {
-                background: linear-gradient(180deg, $color-background-field-regular 62.42%, $color-background-field-autofilled-transparent 63.83%, $color-background-field-autofilled 100%);
-                color: $color-text-field-label-autofilled;
-            }
-
-            border: $border-field-autofilled;
-        }
-
-        &:read-only {
-            border: $border-field-readonly;
         }
 
         &:disabled {
-            border: $border-field-disabled;
             color: $color-text-field-control-disabled;
-
-            & ~ .pa-field-label {
-                color: $color-text-field-label-disabled;
-            }
-        }
-    }
-
-    &.pa-field-error {
-        .pa-field-label {
-            color: $color-text-field-label-error;
-        }
-
-        .pa-field-control {
-            border: $border-field-error;
-            background: $color-background-field-error;
-            caret-color: $color-caret-field-control-error;
-
-            &:not(.pa-field-control-filled):not(:active):not(:focus) + .pa-field-label {
-                background: $color-background-field-error;
-            }
-
-            &:not(:disabled):not(:read-only) {
-                &:hover {
-                    border: $border-field-error-hover;
-                }
-
-                &:focus,
-                &:active {
-                    border: $border-field-error-active;
-
-                    & ~ .pa-field-label {
-                        color: $color-text-field-label-error;
-                    }
-                }
-            }
         }
     }
 }

--- a/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
@@ -9,6 +9,7 @@ $rhythm: (
     1.5: ($spacer * 1.5),   //  1.5  unit -  12px -   .75  rem
     2: ($spacer * 2),       //  2    unit -  16px -  1     rem
     3: ($spacer * 3),       //  3    unit -  24px -  1.5   rem
+    3.5: ($spacer * 3.5),   //  3.5  unit -  28px -  1.75   rem
     4: ($spacer * 4),       //  4    unit -  32px -  2     rem
     5: ($spacer * 5),       //  5    unit -  40px -  2.5   rem
     6: ($spacer * 6),       //  6    unit -  48px -  3     rem

--- a/projects/pastanaga-angular/src/styles/theme/_textfield.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_textfield.tokens.scss
@@ -17,6 +17,8 @@ $color-text-field-label-disabled: $color-neutral-light !default;
 $color-text-field-label-error: $color-secondary-regular !default;
 $color-text-field-label-autofilled: $color-autofilled !default;
 
+$scale-text-field-label: 0.8 !default;
+
 //
 // control
 //
@@ -28,10 +30,10 @@ $color-text-field-control-help-regular: $color-neutral-regular !default;
 $color-caret-field-control-active: $color-primary-regular !default;
 $color-caret-field-control-error: $color-secondary-regular !default;
 
-$color-background-field-regular: $color-light-stronger !default;
+$color-background-field-regular: none !default;
 $color-background-field-autofilled: $color-autofilled-background !default;
 $color-background-field-autofilled-transparent: $color-autofilled-background !default;
-$color-background-field-error: $color-light-stronger !default;
+$color-background-field-error: none !default;
 
 //=====================================
 // BORDERS
@@ -39,17 +41,15 @@ $color-background-field-error: $color-light-stronger !default;
 $border-width-regular: 1px !default;
 $border-width-active: 1px !default;
 
-$border-field-regular: $border-width-regular solid $color-neutral-lighter !default;
-$border-field-regular-hover: $border-width-active solid $color-neutral-regular !default;
-$border-field-regular-active: $border-width-active solid $color-primary-regular !default;
+$border-color-field-regular: $color-neutral-lighter !default;
+$border-color-field-hover: $color-neutral-regular !default;
+$border-color-field-active: $color-primary-regular !default;
 
-$border-field-error: $border-width-regular solid $color-secondary-regular !default;
-$border-field-error-hover: $border-width-active solid $color-secondary-regular !default;
-$border-field-error-active: $border-width-active solid $color-secondary-regular !default;
+$border-color-field-error: $color-secondary-regular !default;
 
-$border-field-disabled: $border-width-regular solid $color-neutral-light !default;
-$border-field-readonly: $border-width-regular dashed $color-neutral-light !default;
-$border-field-autofilled: $border-width-regular solid $color-autofilled !default;
+$border-color-field-disabled: $color-neutral-light !default;
+$border-color-field-readonly: $color-neutral-light !default;
+$border-color-field-autofilled: $color-autofilled !default;
 
 $border-radius-field: $border-radius-default !default;
 


### PR DESCRIPTION
  - No background color on text fields by default
  - Text field borders management:
    - No more borders on input themselves
    - Add a new `pa-field-container` carrying the classes for all the states (error, disabled, readonly, focus, has content) - No more background required on labels to have them displayed over the top border
  - Replace border-text-field tokens by border-color-text-field tokens
  - Use this new style structure on all our fields (input, textarea, select)
  - New `TextFieldDirective` managing label width as well as focus and content states
  - Add autofilled input example