### PR TITLE
Text field improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Improvements
 - Add autofilled input example [mpellerin42]
+- Add `pa-field-icon` class on input icon to prevent style leak [mpellerin42]
 
 ### Dependencies
 - Bumps loader-utils from 2.0.2 to 2.0.3 [Dependabot]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
   - Add `externalLabel` input on `TextFieldDirective` (used by all text fields)
 - Toggle: [mpellerin42]
   - add `labelOnRight` option
-  - improve style (help, cursor state)
+  - improve style (spacing, help, cursor state)
   - improve documentation
 - Typography: Add `xs` support for line-height [mpellerin42]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Text fields: [mpellerin42]
   - Add `pa-field-icon` class on input icon to prevent style leak 
   - Add `externalLabel` input on `TextFieldDirective` (used by all text fields)
+- Toggle: [mpellerin42]
+  - add `labelOnRight` option
+  - improve documentation
 
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.58.0 (2022-12-06)
+# 2.58.0 (2022-12-08)
 
 ### Breaking changes
 - Text fields: [mpellerin42]
@@ -23,8 +23,9 @@
   - Add `externalLabel` input on `TextFieldDirective` (used by all text fields)
 - Toggle: [mpellerin42]
   - add `labelOnRight` option
+  - improve style (help, cursor state)
   - improve documentation
-
+- Typography: Add `xs` support for line-height [mpellerin42]
 
 ### Dependencies
 - Bumps loader-utils from 2.0.2 to 2.0.3 [Dependabot]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
 
 ### Improvements
 - Add autofilled input example [mpellerin42]
-- Add `pa-field-icon` class on input icon to prevent style leak [mpellerin42]
+- Text fields: [mpellerin42]
+  - Add `pa-field-icon` class on input icon to prevent style leak 
+  - Add `externalLabel` input on `TextFieldDirective` (used by all text fields)
+
 
 ### Dependencies
 - Bumps loader-utils from 2.0.2 to 2.0.3 [Dependabot]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# 2.57.3 (unreleased)
+# 2.58.0 (2022-12-06)
+
+### Breaking changes
+- Text fields: [mpellerin42]
+  - No more background color on text fields by default
+  - Improve text field border so label doesn't require a background color and border keep space for the label on active and focus states
+  - Replace border-text-field tokens by border-color-text-field token
+  - Text field borders management:
+      - No more borders on input themselves
+      - Add a new `pa-field-container` carrying the classes for all the states (error, disabled, readonly, focus, has content)
+      - No more background required on labels to have them displayed over the top border
+  - Replace border-text-field tokens by border-color-text-field tokens
+  - Use this new style structure on all our fields (input, textarea, select)
+  - New `TextFieldDirective` managing label width as well as focus and content states
+
+### Improvements
+- Add autofilled input example [mpellerin42]
 
 ### Dependencies
 - Bumps loader-utils from 2.0.2 to 2.0.3 [Dependabot]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - New `TextFieldDirective` managing label width as well as focus and content states
   - Update label position to be properly aligned with the top border
     - Add `rhythm(3.5)` value in rhythm map
+    - Add class `no-internal-label` to remove the label space from the top border when label width is 0
 
 ### Improvements
 - Add autofilled input example [mpellerin42]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Replace border-text-field tokens by border-color-text-field tokens
   - Use this new style structure on all our fields (input, textarea, select)
   - New `TextFieldDirective` managing label width as well as focus and content states
+  - Update label position to be properly aligned with the top border
+    - Add `rhythm(3.5)` value in rhythm map
 
 ### Improvements
 - Add autofilled input example [mpellerin42]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4468,9 +4468,9 @@
       }
     },
     "node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -4936,9 +4936,9 @@
       }
     },
     "node_modules/babel-loader/node_modules/loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -14291,9 +14291,9 @@
       }
     },
     "node_modules/resolve-url-loader/node_modules/loader-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -19951,9 +19951,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -20275,9 +20275,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -27096,9 +27096,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6243,9 +6243,9 @@
       "dev": true
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10"
@@ -21252,9 +21252,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "dedent": {

--- a/projects/demo/src/app/demo/pages/form-control-page/usage/pa-form-control-usage.component.html
+++ b/projects/demo/src/app/demo/pages/form-control-page/usage/pa-form-control-usage.component.html
@@ -2,16 +2,21 @@
 <dl>
     <dt>id</dt>
     <dd>id to be used by the directive <small>(optional)</small></dd>
+
     <dt>name</dt>
     <dd>name to use for the form field <small>(optional)</small></dd>
+
     <dt>value</dt>
     <dd>sets the value to the formControl <small>(should not be used in combination with ngModel nor formControl
         directives)</small></dd>
+
     <dt>readonly</dt>
     <dd>sets the formControl to readonly (value can only be updated by parent component) <small>(default:
         false)</small></dd>
+
     <dt>disabled</dt>
     <dd>disable the form control <small>(default: false)</small></dd>
+
     <dt>errorMessage</dt>
     <dd>manually set the control in invalid state with the given error message <small>(optional)</small></dd>
 </dl>

--- a/projects/demo/src/app/demo/pages/input-page/input-page.component.html
+++ b/projects/demo/src/app/demo/pages/input-page/input-page.component.html
@@ -7,14 +7,18 @@
     </pa-demo-description>
 
     <pa-demo-examples>
-        <p>The following input demonstrates error state: type a character and delete it.</p>
+        <p><strong>Error state: type a character and delete it.</strong></p>
         <pa-input [(ngModel)]="model"
-                  name="selectExample"
+                  name="inputExample"
                   required
                   placeholder="Placeholder"
                   help="Display the error state by typing something and deleting it"
                   [errorMessages]="{required: 'Error message: required'}">Required input</pa-input>
 
+        <p><strong>Autofill: click and select browser's suggestion</strong></p>
+        <pa-input name="email"
+                  id="email"
+                  type="text">Autofilled input</pa-input>
         <pa-tabs>
             <pa-tab (click)="selectedTab = 'standalone'"
                     [active]="selectedTab === 'standalone'">Standalone</pa-tab>

--- a/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.html
+++ b/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.html
@@ -18,7 +18,7 @@
                            [labelOnRight]="labelOnRight"
                            [disabled]="disabled"
                            (statusChange)="firstToggleStatus = $event"
-                ></pa-toggle></div>
+                >Label</pa-toggle></div>
             <div class="col-2">Value: {{firstToggle}}, state: {{firstToggleStatus}}</div>
         </div>
 
@@ -41,6 +41,13 @@
                 </div>
             </div>
         </form>
+        <h4>Group of toggles</h4>
+        <div>
+            <pa-toggle labelOnRight [disabled]="disabled" help="Allows to do nice things">Enable some nice feature</pa-toggle>
+            <pa-toggle labelOnRight [disabled]="disabled" help="Displays great stuff">Another great feature</pa-toggle>
+            <pa-toggle labelOnRight [disabled]="disabled" help="Mind blowing feature">You're not ready for this one</pa-toggle>
+            <pa-toggle labelOnRight [disabled]="disabled" help="Ultimate Answer to the Question of life, the Universe and Everything related to it">42</pa-toggle>
+        </div>
     </pa-demo-examples>
     <pa-demo-configuration>
         <div class="pa-demo-configuration-field">

--- a/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.html
+++ b/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.html
@@ -15,6 +15,7 @@
                            name="firstToggle"
                            [(ngModel)]="firstToggle"
                            [hasFocus]="focusedFirstToggle"
+                           [labelOnRight]="labelOnRight"
                            [disabled]="disabled"
                            (statusChange)="firstToggleStatus = $event"
                 ></pa-toggle></div>
@@ -30,6 +31,7 @@
                         name="toggle"
                         formControlName="toggle"
                         help="help text"
+                        [labelOnRight]="labelOnRight"
                         [hasFocus]="focusedToggle"
                         (statusChange)="secondToggleStatus = $event"
                     >Label
@@ -42,15 +44,28 @@
     </pa-demo-examples>
     <pa-demo-configuration>
         <div class="pa-demo-configuration-field">
-            <pa-checkbox id="focusFirstTrigger" [(ngModel)]="focusedFirstToggle">Focused state On first toggle
+            <pa-checkbox id="labelOnRight"
+                         [(ngModel)]="labelOnRight">
+                Display label on the right
             </pa-checkbox>
         </div>
         <div class="pa-demo-configuration-field">
-            <pa-checkbox id="focusTrigger" [(ngModel)]="focusedToggle">Focused state On Second toggle</pa-checkbox>
+            <pa-checkbox id="focusFirstTrigger"
+                         [(ngModel)]="focusedFirstToggle">
+                Focused state On first toggle
+            </pa-checkbox>
         </div>
         <div class="pa-demo-configuration-field">
-            <pa-checkbox id="disabledTrigger" [(ngModel)]="disabled" (ngModelChange)="toggleDisabled()">Toggle
-                disabled
+            <pa-checkbox id="focusTrigger"
+                         [(ngModel)]="focusedToggle">
+                Focused state On Second toggle
+            </pa-checkbox>
+        </div>
+        <div class="pa-demo-configuration-field">
+            <pa-checkbox id="disabledTrigger"
+                         [(ngModel)]="disabled"
+                         (ngModelChange)="toggleDisabled()">
+                Toggle disabled
             </pa-checkbox>
         </div>
     </pa-demo-configuration>
@@ -64,6 +79,12 @@
         <dl>
             <dt>hasFocus</dt>
             <dd>Set to true to give focus on the input by default <small>(default: false)</small></dd>
+
+            <dt>help</dt>
+            <dd>Display the provided help message under the toggle <small>(Optional)</small></dd>
+
+            <dt>labelOnRight</dt>
+            <dd>Display the label on the right of the toggle <small>(default: false)</small></dd>
         </dl>
     </pa-demo-usage>
 

--- a/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.ts
+++ b/projects/demo/src/app/demo/pages/toggle-page/toggle-page.component.ts
@@ -16,6 +16,7 @@ export class TogglePageComponent {
     focusedFirstToggle = false;
     focusedToggle = false;
     disabled = false;
+    labelOnRight = false;
 
     code = `<pa-toggle
     id="firstToggle"

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.57.2",
+    "version": "2.58.0",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/textfield/index.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/index.ts
@@ -7,5 +7,6 @@ export * from './select';
 
 export * from './textarea';
 
+export * from './text-field.directive';
 export * from './text-field.module';
 export * from './text-field-utility.service';

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
@@ -1,6 +1,7 @@
 <div class="pa-field"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
+         [class.no-internal-label]="labelWidth === '0px'"
          [class.pa-focus]="hasFocus"
          [class.pa-content]="hasContent"
          [class.pa-disabled]="disabled || readonly"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
@@ -35,7 +35,10 @@
         </label>
     </div>
 
-    <pa-icon *ngIf="!!icon" [name]="icon" [class.pa-icon-on-right]="iconOnRight"></pa-icon>
+    <pa-icon *ngIf="!!icon"
+             [name]="icon"
+             [class.pa-icon-on-right]="iconOnRight"
+             class="pa-field-icon"></pa-icon>
 
     <pa-form-field-hint
         [id]="describedById"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
@@ -1,31 +1,39 @@
 <div class="pa-field"
-     [class.pa-field-error]="control.dirty && control.invalid">
-    <input #htmlInput
-           class="pa-field-control"
-           [class.pa-field-control-filled]="isFilled"
-           [class.pa-field-control-icon]="!!icon"
-           [class.pa-icon-on-right]="iconOnRight"
-           [formControl]="control"
-           [id]="id"
-           [attr.name]="name"
-           [type]="type"
-           [attr.maxlength]="maxlength"
-           [attr.aria-describedby]="describedById"
-           [attr.placeholder]="placeholder"
-           [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
-           [attr.autocapitalize]="autocapitalize || undefined"
-           [readonly]="readonly"
-           [paInputFormatter]="sanitizeHtmlTags"
-           (blur)="onBlur()"
-           (keyup)="onKeyUp($event)"
-           (focus)="onFocus($event)"
-    >
-    <label class="pa-field-label"
-           [class.pa-field-label-icon]="!!icon"
-           [class.pa-icon-on-right]="iconOnRight"
-           [for]="id">
-        <ng-content></ng-content>
-    </label>
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-focus]="hasFocus"
+         [class.pa-content]="hasContent"
+         [class.pa-disabled]="disabled || readonly"
+         [class.pa-readonly]="readonly"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <input #htmlInput
+               class="pa-field-control"
+               [class.pa-field-control-filled]="isFilled"
+               [class.pa-field-control-icon]="!!icon"
+               [class.pa-icon-on-right]="iconOnRight"
+               [formControl]="control"
+               [id]="id"
+               [attr.name]="name"
+               [type]="type"
+               [attr.maxlength]="maxlength"
+               [attr.aria-describedby]="describedById"
+               [attr.placeholder]="placeholder"
+               [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
+               [attr.autocapitalize]="autocapitalize || undefined"
+               [readonly]="readonly"
+               [paInputFormatter]="sanitizeHtmlTags"
+               (focus)="onFocus($event)"
+               (blur)="onBlur()"
+               (keyup)="onKeyUp($event)"
+        >
+
+        <label class="pa-field-label"
+               [class.pa-field-label-icon]="!!icon"
+               [class.pa-icon-on-right]="iconOnRight"
+               [for]="id">
+            <ng-content></ng-content>
+        </label>
+    </div>
 
     <pa-icon *ngIf="!!icon" [name]="icon" [class.pa-icon-on-right]="iconOnRight"></pa-icon>
 

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.html
@@ -1,7 +1,7 @@
 <div class="pa-field"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
-         [class.no-internal-label]="labelWidth === '0px'"
+         [class.no-internal-label]="noLabel"
          [class.pa-focus]="hasFocus"
          [class.pa-content]="hasContent"
          [class.pa-disabled]="disabled || readonly"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/input/input.component.spec.ts
@@ -50,8 +50,11 @@ describe('InputComponent', () => {
             PaFormControlDirective,
             InputFormatterDirective,
             MockComponent(FormFieldHintComponent),
-            MockPipe(TranslatePipe, jest.fn((key: string) => key))
-        ]
+            MockPipe(
+                TranslatePipe,
+                jest.fn((key: string) => key),
+            ),
+        ],
     });
 
     const thenInputHasAttribute = (attribute: string, value: any) => {
@@ -93,7 +96,7 @@ describe('InputComponent', () => {
         expect(component.control.value).toEqual(null);
         host.value = 'a parent value';
         spectator.detectChanges();
-        tick();
+        tick(100);
         expect(component.control.value).toEqual('a parent value');
         thenInputHasProperty('value', 'a parent value');
     }));

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -1,7 +1,7 @@
 <div class="pa-field pa-select"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
-         [class.no-internal-label]="labelWidth === '0px'"
+         [class.no-internal-label]="noLabel"
          [class.pa-dim]="dim"
          [class.pa-focus]="isOpened"
          [class.pa-content]="hasContent"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -1,39 +1,44 @@
 <div class="pa-field pa-select"
-     [class.pa-field-readonly]="readonly"
-     [class.pa-field-disabled]="control.disabled"
-     [class.pa-field-error]="control.dirty && control.invalid">
-    <div #selectInput
-         class="select-input pa-field-control"
-         paFocusable
-         cdkMonitorElementFocus
-         sameWidth
-         [class.pa-field-control-filled]="hasValue || isOpened"
-         [class.read-only]="readonly"
-         [class.disabled]="control.disabled"
-         [class.dim]="dim"
-         [class.expanded]="isOpened"
-         [id]="id"
-         [attr.name]="name"
-         [attr.aria-label]="label"
-         [attr.aria-describedby]="describedById"
-         [paPopup]="optionsDropdown"
-         [popupVerticalOffset]="0"
-         [popupDisabled]="control.disabled || readonly"
-         (cdkFocusChange)="onControlFocused($event)">
-        <span class="pa-select-value"
-              [class.placeholder]="!hasValue"
-              [class.active]="isOpened"
-        >{{displayedValue}}</span>
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-dim]="dim"
+         [class.pa-focus]="isOpened"
+         [class.pa-content]="hasContent"
+         [class.pa-readonly]="readonly"
+         [class.pa-disabled]="control.disabled"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <div #selectInput
+             class="select-input pa-field-control"
+             tabindex="0"
+             cdkMonitorElementFocus
+             sameWidth
+             [class.pa-field-control-filled]="hasValue || isOpened"
+             [class.read-only]="readonly"
+             [class.disabled]="control.disabled"
+             [class.expanded]="isOpened"
+             [id]="id"
+             [attr.name]="name"
+             [attr.aria-label]="label"
+             [attr.aria-describedby]="describedById"
+             [paPopup]="optionsDropdown"
+             [popupVerticalOffset]="0"
+             [popupDisabled]="control.disabled || readonly"
+             (cdkFocusChange)="onControlFocused($event)">
+            <span class="pa-select-value"
+                  [class.placeholder]="!hasValue"
+                  [class.active]="isOpened"
+            >{{displayedValue}}</span>
+        </div>
+
+        <label class="pa-field-label"
+               [class.pa-sr-only]="dim && (hasValue || isOpened)"
+               [for]="id">{{label}}</label>
+
+        <pa-icon class="pa-select-chevron"
+                 name="chevron-down"
+                 [class.opened]="isOpened"
+                 (click)="toggleDropdown()"></pa-icon>
     </div>
-
-    <label class="pa-field-label"
-           [class.pa-sr-only]="dim && (hasValue || isOpened)"
-           [for]="id">{{label}}</label>
-
-    <pa-icon class="pa-select-chevron"
-             name="chevron-down"
-             [class.opened]="isOpened"
-             (click)="toggleDropdown()"></pa-icon>
 
     <pa-form-field-hint
         [id]="describedById"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.html
@@ -1,6 +1,7 @@
 <div class="pa-field pa-select"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
+         [class.no-internal-label]="labelWidth === '0px'"
          [class.pa-dim]="dim"
          [class.pa-focus]="isOpened"
          [class.pa-content]="hasContent"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
@@ -147,7 +147,7 @@ describe('SelectComponent', () => {
         thenSelectIsNotValuated();
         host.value = '1';
         spectator.detectChanges();
-        tick();
+        tick(100);
         thenSelectHasValue('1', '1');
         expect(spectator.queryAll('pa-dropdown pa-select-options pa-option .pa-option-selected')).toHaveLength(1);
         discardPeriodicTasks();
@@ -189,7 +189,7 @@ describe('SelectComponent', () => {
 
     it('should propagate ngModel value', fakeAsync(() => {
         initWithTemplate(`<pa-select [(ngModel)]="value">${optionsInTemplate}</pa-select>`);
-        tick();
+        tick(100);
         whenFirstOptionClicked();
         thenSelectHasValue('first', 'first label');
         expect(host.value).toEqual('first');
@@ -220,7 +220,7 @@ describe('SelectComponent', () => {
         expect(spectator.query('.pa-select-value')?.innerHTML).toEqual('');
         host.placeholder = 'placeholder';
         spectator.detectChanges();
-        tick();
+        tick(100);
         expect(spectator.query('.pa-select-value')?.innerHTML).toEqual('placeholder');
         whenFirstOptionClicked();
         expect(spectator.query('.pa-select-value')?.innerHTML).toEqual('first label');
@@ -269,7 +269,7 @@ describe('SelectComponent', () => {
         const expanded = jest.spyOn(host, 'onExpanded');
         host.hasFocus = true;
         spectator.detectChanges();
-        tick();
+        tick(100);
         expect(selectClicked).toHaveBeenCalled();
         expect(expanded).toHaveBeenCalledWith(true);
         spectator.detectChanges();
@@ -282,7 +282,7 @@ describe('SelectComponent', () => {
         expect(spectator.query('.pa-select-chevron')).toBeTruthy();
         expect(spectator.query('.pa-select-chevron.opened')).toEqual(null);
         spectator.click('.pa-field-control');
-        tick();
+        tick(100);
         spectator.detectChanges();
         expect(spectator.query('.pa-select-chevron.opened')).toBeTruthy();
         discardPeriodicTasks();
@@ -291,7 +291,7 @@ describe('SelectComponent', () => {
         initWithTemplate(`<pa-select [readonly]="readonly">${optionsInTemplate}</pa-select>`);
         expect((spectator.query<HTMLElement>('.pa-popup') as any).hidden).toEqual(true);
         spectator.click('.pa-select-chevron');
-        tick();
+        tick(100);
         spectator.detectChanges();
         expect((spectator.query<HTMLElement>('.pa-popup') as any).hidden).toEqual(false);
         spectator.click('.pa-select-chevron');
@@ -311,7 +311,7 @@ describe('SelectComponent', () => {
         expect(component.control.pristine).toEqual(true);
         expect(component.control.touched).toEqual(false);
         spectator.click('.pa-field-control');
-        tick();
+        tick(100);
         spectator.detectChanges();
         spectator.triggerEventHandler(DropdownComponent, 'onClose', true);
         expect(component.control.pristine).toEqual(false);
@@ -325,7 +325,7 @@ describe('SelectComponent', () => {
         const selectClicked = jest.spyOn(component.selectInput?.nativeElement, 'click');
         spectator.triggerEventHandler(CdkMonitorFocus, 'cdkFocusChange', 'keyboard');
         spectator.detectChanges();
-        tick();
+        tick(100);
         expect(selectClicked).toHaveBeenCalled();
         spectator.detectChanges();
         expect((spectator.query<HTMLElement>('.pa-popup') as any).hidden).toEqual(false);
@@ -349,7 +349,7 @@ describe('SelectComponent', () => {
         expect(component.control.valid).toEqual(true);
         const statusChanged = jest.spyOn(host, 'statusChanged');
         host.required = true;
-        tick();
+        tick(100);
         spectator.detectChanges();
         expect(component.control.valid).toEqual(false);
         expect(spectator.query('.pa-field-error')).toBeTruthy();
@@ -364,7 +364,7 @@ describe('SelectComponent', () => {
         component.control.markAsDirty();
         expect(component.control.valid).toEqual(true);
         host.required = true;
-        tick();
+        tick(100);
         spectator.detectChanges();
         expect(component.control.valid).toEqual(false);
         const hint = ngMocks.find(spectator.debugElement, FormFieldHintComponent);
@@ -378,7 +378,7 @@ describe('SelectComponent', () => {
 
     it('should render in dim mode', fakeAsync(() => {
         initWithTemplate(`<pa-select label="my field" dim>${optionsInTemplate}</pa-select>`);
-        tick();
+        tick(100);
         expect(spectator.query('.pa-field-container.pa-dim')).toBeTruthy();
         whenFirstOptionClicked();
         expect(spectator.query('label.pa-sr-only')).toBeTruthy();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
@@ -4,15 +4,15 @@ import { SelectComponent } from './select.component';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { FormFieldHintComponent, PaFormControlDirective } from '../../form-field';
 import { MockComponent, MockModule, MockPipe, MockProvider, ngMocks } from 'ng-mocks';
-import { PaDropdownModule, DropdownComponent } from '../../../dropdown';
+import { DropdownComponent, PaDropdownModule } from '../../../dropdown';
 import { PaPopupModule } from '../../../popup';
 import { SelectOptionsComponent } from './select-options/select-options.component';
 import { PaIconModule } from '../../../icon';
-import { fakeAsync, discardPeriodicTasks, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
 import { OptionHeaderModel, OptionModel, OptionSeparator } from '../../control.model';
 import { SvgIconRegistryService } from 'angular-svg-icon';
 import { A11yModule, CdkMonitorFocus } from '@angular/cdk/a11y';
-import { PA_LANG, PA_TRANSLATIONS, TranslatePipe, PaTranslateModule } from '../../../translate';
+import { PA_LANG, PA_TRANSLATIONS, PaTranslateModule, TranslatePipe } from '../../../translate';
 
 @Component({ template: '' })
 class TestComponent {
@@ -228,21 +228,21 @@ describe('SelectComponent', () => {
 
     it('should apply disabled in standalone', () => {
         initWithTemplate(`<pa-select [value]="value" [disabled]="disabled">${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-disabled')).toEqual(null);
+        expect(spectator.query('.pa-disabled')).toEqual(null);
         host.disabled = true;
         spectator.detectChanges();
         expect(component.control.disabled).toEqual(true);
-        expect(spectator.query('.pa-field-disabled')).toBeTruthy();
+        expect(spectator.query('.pa-disabled')).toBeTruthy();
     });
 
     it('should apply disabled in formGroup', () => {
         initWithTemplate(
             `<form [formGroup]="formGroup"><pa-select formControlName="control">${optionsInTemplate}</pa-select></form>`,
         );
-        expect(spectator.query('.pa-field-disabled')).toEqual(null);
+        expect(spectator.query('.pa-disabled')).toEqual(null);
         host.formGroup.disable();
         expect(component.control.disabled).toEqual(true);
-        expect(spectator.query('.pa-field-disabled')).toBeTruthy();
+        expect(spectator.query('.pa-disabled')).toBeTruthy();
         // value is not updated
         whenFirstOptionClicked();
         expect(component.control.value).toEqual(null);
@@ -250,10 +250,10 @@ describe('SelectComponent', () => {
 
     it('should apply readonly', () => {
         initWithTemplate(`<pa-select [value]="value" [readonly]="readonly">${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-readonly')).toEqual(null);
+        expect(spectator.query('.pa-readonly')).toEqual(null);
         host.readonly = true;
         spectator.detectChanges();
-        expect(spectator.query('.pa-field-readonly')).toBeTruthy();
+        expect(spectator.query('.pa-readonly')).toBeTruthy();
         // value is not updated
         whenFirstOptionClicked();
         expect(component.control.value).toEqual(null);
@@ -377,7 +377,7 @@ describe('SelectComponent', () => {
 
     it('should render in dim mode', fakeAsync(() => {
         initWithTemplate(`<pa-select label="my field" dim>${optionsInTemplate}</pa-select>`);
-        expect(spectator.query('.pa-field-control.dim')).toBeTruthy();
+        expect(spectator.query('.pa-field-container.pa-dim')).toBeTruthy();
         whenFirstOptionClicked();
         expect(spectator.query('label.pa-sr-only')).toBeTruthy();
         discardPeriodicTasks();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
@@ -189,6 +189,7 @@ describe('SelectComponent', () => {
 
     it('should propagate ngModel value', fakeAsync(() => {
         initWithTemplate(`<pa-select [(ngModel)]="value">${optionsInTemplate}</pa-select>`);
+        tick();
         whenFirstOptionClicked();
         thenSelectHasValue('first', 'first label');
         expect(host.value).toEqual('first');
@@ -377,6 +378,7 @@ describe('SelectComponent', () => {
 
     it('should render in dim mode', fakeAsync(() => {
         initWithTemplate(`<pa-select label="my field" dim>${optionsInTemplate}</pa-select>`);
+        tick();
         expect(spectator.query('.pa-field-container.pa-dim')).toBeTruthy();
         whenFirstOptionClicked();
         expect(spectator.query('label.pa-sr-only')).toBeTruthy();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.ts
@@ -25,8 +25,8 @@ import { detectChanges, isVisibleInViewport, markForCheck } from '../../../commo
 import { fromEvent, Subject } from 'rxjs';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { PaFormControlDirective } from '../../form-field';
 import { IErrorMessages } from '../../form-field.model';
+import { TextFieldDirective } from '../text-field.directive';
 
 type OptionType = OptionModel | OptionSeparator | OptionHeaderModel;
 
@@ -35,18 +35,13 @@ type OptionType = OptionModel | OptionSeparator | OptionHeaderModel;
     templateUrl: './select.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SelectComponent extends PaFormControlDirective implements OnChanges, AfterViewInit, OnDestroy {
+export class SelectComponent extends TextFieldDirective implements OnChanges, AfterViewInit, OnDestroy {
     @Input() label = '';
     @Input() placeholder?: string;
 
     @Input() set options(values: OptionType[]) {
         this.dropDownModels = !!values ? values : [];
         this._updateDisplayedValue(this.control.value);
-    }
-
-    @Input() set hasFocus(value: any) {
-        this._hasFocus = coerceBooleanProperty(value);
-        this._focusInput();
     }
 
     @Input() adjustHeight = false;
@@ -80,7 +75,6 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
     displayedValue?: string;
     private optionsClosed$ = new Subject<void>();
     private contentOptionsChanged$ = new Subject<void>();
-    private _hasFocus = false;
     private _dim = false;
 
     protected _terminator = new Subject<void>();
@@ -110,10 +104,12 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
         }
     }
 
-    ngAfterViewInit(): void {
+    override ngAfterViewInit(): void {
+        super.ngAfterViewInit();
+
         this._handleNgContent();
         this._checkDescribedBy();
-        this._focusInput();
+        this.focusInput();
         this._updateDisplayedValue(this.control.value);
         // valueChanges may be triggered by an update value and validity...
         // we don't want to recompute the displayed option label in that case
@@ -182,8 +178,8 @@ export class SelectComponent extends PaFormControlDirective implements OnChanges
         }
     }
 
-    private _focusInput() {
-        if (this._hasFocus && this.isActive) {
+    override focusInput() {
+        if (this.hasFocus && this.isActive) {
             this._openOptionDropDown();
             if (!isVisibleInViewport(this.selectInput?.nativeElement)) {
                 this.selectInput?.nativeElement.scrollIntoView();

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
@@ -27,10 +27,12 @@ export class TextFieldDirective extends PaFormControlDirective implements AfterV
     }
 
     ngAfterViewInit() {
-        const label = this.element.nativeElement.querySelector('.pa-field-label');
-        if (label) {
-            this._labelWidth = label.getBoundingClientRect().width;
-        }
+        setTimeout(() => {
+            const label = this.element.nativeElement.querySelector('.pa-field-label');
+            if (label) {
+                this._labelWidth = label.getBoundingClientRect().width;
+            }
+        });
     }
 
     onFocus(event: any) {

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
@@ -30,9 +30,10 @@ export class TextFieldDirective extends PaFormControlDirective implements AfterV
         setTimeout(() => {
             const label = this.element.nativeElement.querySelector('.pa-field-label');
             if (label) {
-                this._labelWidth = label.getBoundingClientRect().width;
+                this._labelWidth = label.getBoundingClientRect().width || 0;
+                this.cdr.markForCheck();
             }
-        });
+        }, 100);
     }
 
     onFocus(event: any) {

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
@@ -15,8 +15,14 @@ export class TextFieldDirective extends PaFormControlDirective implements AfterV
         return this._hasFocus;
     }
 
+    @Input()
+    set externalLabel(value: any) {
+        this._externalLabel = coerceBooleanProperty(value);
+    }
+
     private _hasFocus = false;
     private _labelWidth?: number;
+    private _externalLabel = false;
 
     get hasContent() {
         return this.control.value?.length > 0;
@@ -24,6 +30,9 @@ export class TextFieldDirective extends PaFormControlDirective implements AfterV
 
     get labelWidth() {
         return `${this._labelWidth}px`;
+    }
+    get noLabel() {
+        return this._externalLabel || this.labelWidth === '0px';
     }
 
     ngAfterViewInit() {

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.directive.ts
@@ -1,0 +1,47 @@
+import { PaFormControlDirective } from '../form-field';
+import { AfterViewInit, Directive, Input } from '@angular/core';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+
+@Directive({
+    selector: '[paTextField]',
+})
+export class TextFieldDirective extends PaFormControlDirective implements AfterViewInit {
+    @Input()
+    set hasFocus(value: any) {
+        this._hasFocus = coerceBooleanProperty(value);
+        this.focusInput();
+    }
+    get hasFocus() {
+        return this._hasFocus;
+    }
+
+    private _hasFocus = false;
+    private _labelWidth?: number;
+
+    get hasContent() {
+        return this.control.value?.length > 0;
+    }
+
+    get labelWidth() {
+        return `${this._labelWidth}px`;
+    }
+
+    ngAfterViewInit() {
+        const label = this.element.nativeElement.querySelector('.pa-field-label');
+        if (label) {
+            this._labelWidth = label.getBoundingClientRect().width;
+        }
+    }
+
+    onFocus(event: any) {
+        this._hasFocus = true;
+    }
+
+    onBlur() {
+        this._hasFocus = false;
+    }
+
+    focusInput() {
+        // To be overridden
+    }
+}

--- a/projects/pastanaga-angular/src/lib/controls/textfield/text-field.module.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/text-field.module.ts
@@ -12,6 +12,7 @@ import { SelectComponent, SelectOptionsComponent } from './select';
 import { PaTextareaAutoHeightDirective, TextareaComponent } from './textarea';
 import { NativeTextFieldDirective } from './native-text-field.directive';
 import { PaDropdownModule, OptionComponent, OptionHeaderComponent, SeparatorComponent } from '../../dropdown';
+import { TextFieldDirective } from './text-field.directive';
 
 @NgModule({
     declarations: [
@@ -22,6 +23,7 @@ import { PaDropdownModule, OptionComponent, OptionHeaderComponent, SeparatorComp
         TextareaComponent,
         NativeTextFieldDirective,
         PaTextareaAutoHeightDirective,
+        TextFieldDirective,
     ],
     imports: [
         CommonModule,

--- a/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
@@ -1,6 +1,7 @@
 <div class="pa-field"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
+         [class.no-internal-label]="labelWidth === '0px'"
          [class.pa-focus]="hasFocus"
          [class.pa-content]="hasContent"
          [class.pa-disabled]="disabled || readonly"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
@@ -1,7 +1,7 @@
 <div class="pa-field"
      [style.--label-width]="labelWidth">
     <div class="pa-field-container"
-         [class.no-internal-label]="labelWidth === '0px'"
+         [class.no-internal-label]="noLabel"
          [class.pa-focus]="hasFocus"
          [class.pa-content]="hasContent"
          [class.pa-disabled]="disabled || readonly"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.html
@@ -1,27 +1,35 @@
-<div class="pa-field" [class.pa-field-error]="control.dirty && control.invalid">
-    <textarea #htmlInput
-              class="pa-field-control pa-field-textarea"
-              [class.pa-field-control-filled]="isFilled"
-              [class.pa-text-area-resizable]="resizable"
-              [formControl]="control"
-              [id]="id"
-              [attr.name]="name"
-              [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
-              [attr.placeholder]="placeholder"
-              [attr.maxlength]="maxlength"
-              [attr.aria-describedby]="describedById"
-              [readonly]="readonly"
-              [paTextareaAutoHeight]="autoHeight"
-              [paTextareaMaxHeight]="autoMaxHeight"
-              [attr.rows]="rows"
-              [paInputFormatter]="sanitizeHtmlTags"
-              (blur)="onBlur()"
-              (keyup)="onKeyUp($event)"
-              (focus)="onFocus($event)"
-    ></textarea>
-    <label class="pa-field-label" [for]="id" aria-hidden="true">
-        <ng-content></ng-content>
-    </label>
+<div class="pa-field"
+     [style.--label-width]="labelWidth">
+    <div class="pa-field-container"
+         [class.pa-focus]="hasFocus"
+         [class.pa-content]="hasContent"
+         [class.pa-disabled]="disabled || readonly"
+         [class.pa-readonly]="readonly"
+         [class.pa-field-error]="control.dirty && control.invalid">
+        <textarea #htmlInput
+                  class="pa-field-control pa-field-textarea"
+                  [class.pa-field-control-filled]="isFilled"
+                  [class.pa-text-area-resizable]="resizable"
+                  [formControl]="control"
+                  [id]="id"
+                  [attr.name]="name"
+                  [attr.autocomplete]="noAutoComplete ? 'off' : undefined"
+                  [attr.placeholder]="placeholder"
+                  [attr.maxlength]="maxlength"
+                  [attr.aria-describedby]="describedById"
+                  [readonly]="readonly"
+                  [paTextareaAutoHeight]="autoHeight"
+                  [paTextareaMaxHeight]="autoMaxHeight"
+                  [attr.rows]="rows"
+                  [paInputFormatter]="sanitizeHtmlTags"
+                  (blur)="onBlur()"
+                  (keyup)="onKeyUp($event)"
+                  (focus)="onFocus($event)"
+        ></textarea>
+        <label class="pa-field-label" [for]="id" aria-hidden="true">
+            <ng-content></ng-content>
+        </label>
+    </div>
 
     <pa-form-field-hint
         [id]="describedById"

--- a/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/textarea/textarea.component.spec.ts
@@ -98,7 +98,7 @@ describe('TextareaComponent', () => {
         expect(component.control.value).toEqual(null);
         host.value = 'a parent value';
         spectator.detectChanges();
-        tick();
+        tick(100);
         expect(component.control.value).toEqual('a parent value');
         thenInputHasProperty('value', 'a parent value');
     }));
@@ -214,7 +214,7 @@ describe('TextareaComponent', () => {
 
         host.maxlength = 3;
         spectator.detectChanges();
-        tick(1);
+        tick(100);
         spectator.detectChanges();
         thenInputHasProperty('maxLength', 3);
         thenInputHasAttribute('maxlength', '3');
@@ -224,7 +224,7 @@ describe('TextareaComponent', () => {
             `<pa-textarea [(ngModel)]="model" [required]="required" [errorMessages]="errorMessages">Label</pa-textarea>`,
         );
         host.required = true;
-        tick();
+        tick(100);
         spectator.detectChanges();
 
         component.control.markAsDirty();
@@ -242,7 +242,7 @@ describe('TextareaComponent', () => {
             `<pa-textarea [(ngModel)]="model" [required]="required" [showAllErrors]="showAllErrors">Label</pa-textarea>`,
         );
         host.required = true;
-        tick();
+        tick(100);
         spectator.detectChanges();
 
         component.control.markAsDirty();

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
@@ -1,7 +1,11 @@
-<div class="pa-field" [class.pa-field-error]="control.dirty && control.invalid">
-    <div class="pa-toggle-context" (click)="updateState(!isChecked)">
+<div class="pa-field"
+     [class.pa-field-error]="control.dirty && control.invalid">
+    <div class="pa-toggle-context"
+         [class.pa-label-on-right]="labelOnRight"
+         (click)="updateState(!isChecked)">
         <div class="pa-toggle-label-container" *ngIf="hasLabel">
-            <label #label [for]="id"
+            <label #label
+                   [for]="id"
                    class="pa-field-label"
                    aria-hidden="true"
             >

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
@@ -1,4 +1,5 @@
 <div class="pa-field"
+     [class.pa-has-help]="!!help"
      [class.pa-disable]="control.disabled"
      [class.pa-field-error]="control.dirty && control.invalid">
     <div class="pa-toggle-context"

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
@@ -1,4 +1,5 @@
 <div class="pa-field"
+     [class.pa-disable]="control.disabled"
      [class.pa-field-error]="control.dirty && control.invalid">
     <div class="pa-toggle-context"
          [class.pa-label-on-right]="labelOnRight"

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.html
@@ -3,11 +3,14 @@
     <div class="pa-toggle-context"
          [class.pa-label-on-right]="labelOnRight"
          (click)="updateState(!isChecked)">
-        <div class="pa-toggle-label-container" *ngIf="hasLabel">
+        <div class="pa-toggle-label-container"
+             tabindex="-1"
+             *ngIf="hasLabel">
             <label #label
                    [for]="id"
                    class="pa-field-label"
                    aria-hidden="true"
+                   (click)="updateState(!isChecked)"
             >
                 <ng-content></ng-content>
             </label>
@@ -20,7 +23,9 @@
             ></pa-form-field-hint>
         </div>
         <div class="pa-toggle-container"
-             [ngClass]="{checked: isChecked, focused: hasFocus, disabled: control.disabled}"
+             [class.pa-checked]="isChecked"
+             [class.pa-disable]="control.disabled"
+             [class.pa-focus]="hasFocus"
         >
             <input #inputElement
                    type="checkbox"

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
@@ -42,6 +42,12 @@ $toggle-transition-duration: $duration-fast;
             cursor: default;
         }
     }
+
+    &.pa-has-help {
+        .pa-field-label {
+            margin-top: -#{rhythm(0.5)};
+        }
+    }
 }
 
 .pa-toggle-container {

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
@@ -28,6 +28,7 @@ $toggle-transition-duration: $duration-fast;
 
         .pa-field-label {
             color: $color-dark-stronger;
+            cursor: pointer;
             position: inherit;
             max-width: 100%;
         }
@@ -70,12 +71,12 @@ $toggle-transition-duration: $duration-fast;
             right: $toggle-full-mid-width + $toggle-slider-padding;
             bottom: $toggle-slider-padding;
             left: $toggle-slider-padding;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+            box-shadow: 0 rhythm(0.25) rhythm(0.5) rgba(0, 0, 0, 0.15);
             background-color: $color-light-stronger;
         }
     }
 
-    &.checked {
+    &.pa-checked {
         .pa-toggle-slider {
             background: $color-primary-regular;
             &:before {
@@ -84,11 +85,11 @@ $toggle-transition-duration: $duration-fast;
         }
     }
 
-    &.focused .pa-toggle-slider {
+    &:focus-within .pa-toggle-slider {
         box-shadow: $shadow-focus;
     }
 
-    &.disabled {
+    &.pa-disable {
         .pa-toggle-slider {
             cursor: default;
             background: $color-neutral-light;

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
@@ -32,6 +32,18 @@ $toggle-transition-duration: $duration-fast;
             position: inherit;
             max-width: 100%;
         }
+        pa-form-field-hint ::ng-deep .pa-field-help {
+            margin-top: 0;
+        }
+    }
+
+    &.pa-disable {
+        .pa-toggle-label-container {
+            cursor: default;
+        }
+        .pa-field-label {
+            cursor: default;
+        }
     }
 }
 

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
@@ -27,10 +27,7 @@ $toggle-transition-duration: $duration-fast;
         flex-direction: column;
 
         .pa-field-label {
-            color: $color-dark-stronger;
             cursor: pointer;
-            position: inherit;
-            max-width: 100%;
         }
         pa-form-field-hint ::ng-deep .pa-field-help {
             margin-top: 0;

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.scss
@@ -13,13 +13,18 @@ $toggle-transition-duration: $duration-fast;
 
     .pa-toggle-context {
         display: flex;
-        justify-content: space-between;
+        gap: rhythm(2);
+        justify-content: flex-end;
+
+        &.pa-label-on-right {
+            flex-direction: row-reverse;
+        }
     }
 
     .pa-toggle-label-container {
+        cursor: pointer;
         display: flex;
         flex-direction: column;
-        margin: auto rhythm(2) auto auto;
 
         .pa-field-label {
             color: $color-dark-stronger;
@@ -74,8 +79,6 @@ $toggle-transition-duration: $duration-fast;
         .pa-toggle-slider {
             background: $color-primary-regular;
             &:before {
-                -webkit-transform: translateX($toggle-full-mid-width);
-                -ms-transform: translateX($toggle-full-mid-width);
                 transform: translateX($toggle-full-mid-width);
             }
         }

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.spec.ts
@@ -73,7 +73,7 @@ describe('ToggleComponent', () => {
             host.hasFocus = true;
             spectator.detectChanges();
             tick();
-            expect(spectator.query<HTMLInputElement>('.pa-toggle-container.focused')).toBeTruthy();
+            expect(spectator.query<HTMLInputElement>('.pa-toggle-container.pa-focus')).toBeTruthy();
         }));
 
         it('should support disabling', fakeAsync(() => {

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.ts
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggle/toggle.component.ts
@@ -28,15 +28,23 @@ import { IErrorMessages } from '../../form-field.model';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ToggleComponent extends PaFormControlDirective implements OnInit, OnChanges, AfterViewInit, OnDestroy {
-    @Input() errorMessages?: IErrorMessages;
     @Input()
-    get hasFocus(): boolean {
-        return this._hasFocus;
+    set labelOnRight(value: any) {
+        this._labelOnRight = coerceBooleanProperty(value);
     }
+    get labelOnRight(): boolean {
+        return this._labelOnRight;
+    }
+
+    @Input()
     set hasFocus(value: any) {
         this._hasFocus = coerceBooleanProperty(value);
     }
-    private _hasFocus = false;
+    get hasFocus(): boolean {
+        return this._hasFocus;
+    }
+
+    @Input() errorMessages?: IErrorMessages;
     @Input() help?: string;
 
     @ViewChild('inputElement') input?: ElementRef;
@@ -46,6 +54,9 @@ export class ToggleComponent extends PaFormControlDirective implements OnInit, O
 
     isChecked = false;
     describedById?: string;
+
+    private _hasFocus = false;
+    private _labelOnRight = false;
 
     constructor(
         protected override element: ElementRef,

--- a/projects/pastanaga-angular/src/styles/_checkbox.scss
+++ b/projects/pastanaga-angular/src/styles/_checkbox.scss
@@ -97,16 +97,16 @@
         }
 
         .pa-toggle-control {
-            border: $border-field-error;
+            border-color: $border-color-field-error;
 
             &:not(:disabled) {
                 &:hover {
-                    border: $border-field-error-hover;
+                    border-color: $border-color-field-error;
                 }
 
                 &:focus,
                 &:active {
-                    border: $border-field-error-active;
+                    border-color: $border-color-field-error;
 
                     & ~ .pa-toggle-label {
                         color: $color-text-field-label-error;

--- a/projects/pastanaga-angular/src/styles/_select.scss
+++ b/projects/pastanaga-angular/src/styles/_select.scss
@@ -30,30 +30,30 @@
         right: $icon-right-padding;
         top: rhythm(1.5);
         width: $icon-width;
+
         &.opened {
             transform: rotate(180deg);
         }
     }
-    &.pa-field-disabled {
-        color: $color-text-field-control-disabled;
-        .pa-select-chevron {
-            cursor: default;
+
+    .pa-field-container {
+        &.pa-disabled {
+            color: $color-text-field-control-disabled;
+            .pa-select-chevron {
+                color: $color-text-field-control-disabled;
+            }
+        }
+        &.pa-readonly .pa-select-chevron {
+            color: $color-text-field-control-disabled;
+        }
+        &:not(.pa-disabled):not(.pa-readonly) {
+            cursor: pointer;
         }
     }
-    &.pa-field-readonly {
-        .pa-select-chevron {
-            cursor: default;
-        }
-    }
+
     .pa-field-control {
         padding-right: calc(#{$icon-width + $icon-right-padding});
         width: 100%;
-        cursor: pointer;
-
-        &.pa-keyboard-focus {
-            border: $border-field-autofilled;
-            box-shadow: none;
-        }
     }
     .pa-field-label {
         white-space: nowrap;
@@ -61,54 +61,25 @@
         text-overflow: ellipsis;
         max-width: calc(100% - #{$padding-field-control-left + $icon-width + $icon-right-padding});
     }
-}
 
-.pa-field.pa-select:not(.pa-field-error) {
-    .pa-field-control:read-only {
-        border: $border-field-regular;
+    .pa-dim,
+    .pa-field-container.pa-content.pa-dim {
+        border: 1px solid transparent;
 
-        &:not(.disabled):not(.read-only) {
-            &:hover {
-                border: $border-field-regular-hover;
-                margin: 0;
-            }
-            &:focus,
-            &:active,
-            &.expanded {
-                border: $border-field-regular-active;
-                margin: 0;
-
-                &::placeholder {
-                    opacity: 1;
-                    transition: all 1s ease;
-                }
-
-                &~.pa-field-label {
-                    color: $color-text-field-label-regular-active;
-                }
-            }
+        &::after,
+        &::before {
+            display: none;
         }
-        &.dim:not(:hover):not(:focus):not(:active):not(.expanded) {
-            border-color: transparent;
-            background-color: transparent;
+        &.pa-focus {
+            border: 1px solid $border-color-field-active;
         }
-        &.disabled:not(.dim) {
-            border: $border-field-disabled;
-            color: $color-text-field-control-disabled;
-
-            &~.pa-field-label {
-                color: $color-text-field-label-disabled;
-            }
+        &:not(.pa-focus):not(.pa-disabled):hover {
+            border: 1px solid $border-color-field-hover;
         }
-        &.read-only:not(.dim) {
-            border: $border-field-readonly;
+        &.pa-disabled,
+        &.pa-readonly {
+            border: 1px solid transparent;
         }
-    }
-}
-.pa-field.pa-select.pa-field-error {
-    .pa-field-control:not(.pa-field-control-filled) + .pa-field-label {
-        color: $color-text-field-label-regular;
-        background: $color-background-field-error;
     }
 }
 

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -6,13 +6,10 @@
     position: relative;
     margin-bottom: $margin-bottom-field;
 
-    &:not(.pa-select) pa-icon {
+    .pa-field-icon {
+        color: $color-neutral-regular;
         position: absolute;
         top: $padding-field-control-top;
-
-        svg {
-            fill: $color-neutral-regular;
-        }
 
         &:not(.pa-icon-on-right) {
             left: $padding-field-control-left;

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -150,26 +150,26 @@
                 caret-color: $color-caret-field-control-error;
             }
         }
+    }
 
-        .pa-field-label {
-            position: absolute;
-            font-size: $font-size-field-control;
-            line-height: $line-height-field-control;
-            font-weight: $font-weight-label;
-            color: $color-text-field-label-regular;
-            left: $padding-field-control-left;
-            top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
-            max-width: calc(100% - #{$padding-field-control-left * 2});
-            pointer-events: none;
-            transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
-            transform-origin: 0 0;
+    .pa-field-label {
+        position: absolute;
+        font-size: $font-size-field-control;
+        line-height: $line-height-field-control;
+        font-weight: $font-weight-label;
+        color: $color-text-field-label-regular;
+        left: $padding-field-control-left;
+        top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
+        max-width: calc(100% - #{$padding-field-control-left * 2});
+        pointer-events: none;
+        transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
+        transform-origin: 0 0;
 
-            &.pa-field-label-icon:not(.pa-icon-on-right) {
-                left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
-            }
-            &.pa-field-label-icon.pa-icon-on-right {
-                max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
-            }
+        &.pa-field-label-icon:not(.pa-icon-on-right) {
+            left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+        }
+        &.pa-field-label-icon.pa-icon-on-right {
+            max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
         }
     }
 

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -227,6 +227,9 @@
     }
 }
 
+pa-form-field-hint {
+    line-height: line-height(xs);
+}
 .pa-field-help {
     @include size(xs);
     color: $color-text-field-control-help-regular;

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -40,6 +40,9 @@
             left: calc(var(--label-width) * #{$scale-text-field-label} + #{$padding-field-control-left}*2);
             right: 1px;
         }
+        &.no-internal-label::after {
+            left: 0;
+        }
 
         &:hover {
             border-color: $border-color-field-hover;
@@ -49,16 +52,15 @@
         &:active,
         &.pa-content,
         &.pa-focus {
-            border-top: none;
+            border-top: 1px solid transparent;
         }
         &:focus,
         &:active,
         &.pa-focus {
             border-color: $border-color-field-active;
+            border-top: 1px solid transparent;
         }
         &.pa-content {
-            border-top: none;
-
             &::after,
             &::before {
                 background: $border-color-field-regular;
@@ -100,7 +102,7 @@
             border-color: $border-color-field-readonly;
             border-style: dashed;
             &.pa-content {
-                border-top: none;
+                border-top: 1px solid transparent;
 
                 &::after,
                 &::before {

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -108,11 +108,11 @@
                 &::before {
                     // Not using rhythm here because we want to mimic browser's `border-style: dashed` property
                     background: repeating-linear-gradient(
-                            90deg,
-                            $border-color-field-readonly,
-                            $border-color-field-readonly 3px,
-                            transparent 3px,
-                            transparent 6px
+                        90deg,
+                        $border-color-field-readonly,
+                        $border-color-field-readonly 3px,
+                        transparent 3px,
+                        transparent 6px
                     );
                 }
             }
@@ -139,6 +139,7 @@
                 &.pa-content,
                 &.pa-focus {
                     border-color: $border-color-field-error;
+                    border-top: 1px solid transparent;
                 }
             }
             .pa-field-label {
@@ -150,27 +151,31 @@
                 caret-color: $color-caret-field-control-error;
             }
         }
+        // Definition specific for text field labels
+        .pa-field-label {
+            color: $color-text-field-label-regular;
+            left: $padding-field-control-left;
+            max-width: calc(100% - #{$padding-field-control-left * 2});
+            position: absolute;
+            top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
+            transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
+            transform-origin: 0 0;
+
+            &.pa-field-label-icon:not(.pa-icon-on-right) {
+                left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+            }
+            &.pa-field-label-icon.pa-icon-on-right {
+                max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
+            }
+        }
     }
 
+    // Definition for labels of all pa-fields (including toggle ones)
     .pa-field-label {
-        position: absolute;
         font-size: $font-size-field-control;
         line-height: $line-height-field-control;
         font-weight: $font-weight-label;
-        color: $color-text-field-label-regular;
-        left: $padding-field-control-left;
-        top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
-        max-width: calc(100% - #{$padding-field-control-left * 2});
         pointer-events: none;
-        transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
-        transform-origin: 0 0;
-
-        &.pa-field-label-icon:not(.pa-icon-on-right) {
-            left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
-        }
-        &.pa-field-label-icon.pa-icon-on-right {
-            max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
-        }
     }
 
     .pa-field-control {

--- a/projects/pastanaga-angular/src/styles/_textfields.scss
+++ b/projects/pastanaga-angular/src/styles/_textfields.scss
@@ -1,19 +1,5 @@
 @import "variables";
 
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-textarea:-webkit-autofill,
-textarea:-webkit-autofill:hover,
-textarea:-webkit-autofill:focus,
-select:-webkit-autofill,
-select:-webkit-autofill:hover,
-select:-webkit-autofill:focus {
-    border: $border-field-autofilled;
-    -webkit-text-fill-color: inherit;
-    -webkit-box-shadow: 0 0 0 0 $color-background-field-autofilled inset;
-}
-
 .pa-field {
     $icon-width: rhythm(3);
 
@@ -36,25 +22,155 @@ select:-webkit-autofill:focus {
         }
     }
 
-    .pa-field-label {
-        position: absolute;
-        font-size: $font-size-field-control;
-        line-height: $line-height-field-control;
-        font-weight: $font-weight-label;
-        background: $color-background-field-regular;
-        color: $color-text-field-label-regular;
-        left: $padding-field-control-left;
-        top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
-        max-width: calc(100% - #{$padding-field-control-left * 2});
-        pointer-events: none;
-        transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
-        transform-origin: 0 0;
-
-        &.pa-field-label-icon:not(.pa-icon-on-right) {
-            left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+    .pa-field-container {
+        border: 1px solid $border-color-field-regular;
+        border-radius: $border-radius-field;
+        &::after,
+        &::before {
+            content: '';
+            height: 1px;
+            position: absolute;
+            top: 0;
+            z-index: 1;
         }
-        &.pa-field-label-icon.pa-icon-on-right {
-            max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
+
+        &::before {
+            left: 0;
+            width: rhythm(1);
+        }
+
+        &::after {
+            left: calc(var(--label-width) * #{$scale-text-field-label} + #{$padding-field-control-left}*2);
+            right: 1px;
+        }
+
+        &:hover {
+            border-color: $border-color-field-hover;
+        }
+
+        &:focus,
+        &:active,
+        &.pa-content,
+        &.pa-focus {
+            border-top: none;
+        }
+        &:focus,
+        &:active,
+        &.pa-focus {
+            border-color: $border-color-field-active;
+        }
+        &.pa-content {
+            border-top: none;
+
+            &::after,
+            &::before {
+                background: $border-color-field-regular;
+            }
+            &:not(.pa-focus):not(.pa-disabled):not(.pa-readonly):hover {
+                &::after,
+                &::before {
+                    background: $border-color-field-hover;
+                }
+            }
+        }
+
+        &:not(.pa-disabled):not(.pa-readonly):not(.pa-field-error).pa-focus {
+            &::after,
+            &::before {
+                background: $border-color-field-active;
+            }
+            .pa-field-label {
+                color: $color-text-field-label-regular-active;
+            }
+        }
+
+        &.pa-disabled {
+            border-color: $border-color-field-disabled;
+
+            &::after,
+            &::before {
+                background: $border-color-field-disabled;
+            }
+            .pa-field-label {
+                color: $color-text-field-label-disabled;
+            }
+        }
+        &.pa-readonly {
+            .pa-field-label {
+                color: $color-text-field-label-disabled;
+            }
+
+            border-color: $border-color-field-readonly;
+            border-style: dashed;
+            &.pa-content {
+                border-top: none;
+
+                &::after,
+                &::before {
+                    // Not using rhythm here because we want to mimic browser's `border-style: dashed` property
+                    background: repeating-linear-gradient(
+                            90deg,
+                            $border-color-field-readonly,
+                            $border-color-field-readonly 3px,
+                            transparent 3px,
+                            transparent 6px
+                    );
+                }
+            }
+            &:not(.pa-content) {
+                &::after,
+                &::before {
+                    display: none;
+                }
+            }
+        }
+        &.pa-field-error {
+            &:not(.pa-disabled):not(.pa-readonly) {
+                border-color: $border-color-field-error;
+
+                &::after,
+                &::before {
+                    background: $border-color-field-error;
+                }
+                &:hover {
+                    border-color: $border-color-field-error;
+                }
+                &:focus,
+                &:active,
+                &.pa-content,
+                &.pa-focus {
+                    border-color: $border-color-field-error;
+                }
+            }
+            .pa-field-label {
+                color: $color-text-field-label-error;
+            }
+
+            .pa-field-control {
+                background: $color-background-field-error;
+                caret-color: $color-caret-field-control-error;
+            }
+        }
+
+        .pa-field-label {
+            position: absolute;
+            font-size: $font-size-field-control;
+            line-height: $line-height-field-control;
+            font-weight: $font-weight-label;
+            color: $color-text-field-label-regular;
+            left: $padding-field-control-left;
+            top: calc(#{$padding-field-control-top} + #{rhythm(.25)});
+            max-width: calc(100% - #{$padding-field-control-left * 2});
+            pointer-events: none;
+            transition: transform $transition-hint-duration cubic-bezier(0.4, 0, 0.2, 1); // copied from google transition
+            transform-origin: 0 0;
+
+            &.pa-field-label-icon:not(.pa-icon-on-right) {
+                left: calc(#{$padding-field-control-left} * 2 + #{$icon-width});
+            }
+            &.pa-field-label-icon.pa-icon-on-right {
+                max-width: calc(100% - #{$padding-field-control-left * 2} - #{$icon-width});
+            }
         }
     }
 
@@ -64,8 +180,7 @@ select:-webkit-autofill:focus {
         background: $color-background-field-regular;
         color: $color-text-field-control-regular;
         caret-color: $color-caret-field-control-active;
-        border: $border-field-regular;
-        border-radius: $border-radius-field;
+        border: none;
         padding: $padding-field-control-top $padding-field-control-left;
         outline: none;
         margin: $border-width-active - $border-width-regular;
@@ -85,92 +200,30 @@ select:-webkit-autofill:focus {
         }
 
         &:not(:disabled):not(:read-only) {
-            &:hover {
-                border: $border-field-regular-hover;
-                margin: 0;
-            }
-
             &:focus,
             &:active {
-                border: $border-field-regular-active;
-                margin: 0;
-
                 &::placeholder {
                     opacity: 1;
                     transition: all 1s ease;
-                }
-
-                & ~ .pa-field-label {
-                    color: $color-text-field-label-regular-active;
                 }
             }
         }
 
         &.pa-field-control-filled,
-        &.cdk-text-field-autofilled,
         &:not(:disabled):not(:read-only):focus,
         &:not(:disabled):not(:read-only):active {
             & ~ .pa-field-label {
-                transform: scale(.8) translateY(-#{rhythm(4)}) translateX(-#{rhythm(.5)});
+                transform: scale(#{$scale-text-field-label}) translateY(-#{rhythm(3.5)}) translateX(-#{rhythm(.5)});
                 padding: 0 rhythm(1);
 
                 &.pa-field-label-icon:not(.pa-icon-on-right) {
-                    transform: scale(.8) translateY(-#{rhythm(4)}) translateX(calc(-#{rhythm(.5)} - #{$icon-width} - #{$padding-field-control-left * 2}));
+                    transform: scale(#{$scale-text-field-label}) translateY(-#{rhythm(3.5)}) translateX(calc(-#{rhythm(.5)} - #{$icon-width} - #{$padding-field-control-left * 2}));
                 }
             }
-        }
-
-        &.cdk-text-field-autofilled:not(:disabled):not(:read-only) {
-            & ~ .pa-field-label {
-                background: linear-gradient(180deg, $color-background-field-regular 62.42%, $color-background-field-autofilled-transparent 63.83%, $color-background-field-autofilled 100%);
-                color: $color-text-field-label-autofilled;
-            }
-
-            border: $border-field-autofilled;
-        }
-
-        &:read-only {
-            border: $border-field-readonly;
         }
 
         &:disabled {
-            border: $border-field-disabled;
             color: $color-text-field-control-disabled;
-
-            & ~ .pa-field-label {
-                color: $color-text-field-label-disabled;
-            }
-        }
-    }
-
-    &.pa-field-error {
-        .pa-field-label {
-            color: $color-text-field-label-error;
-        }
-
-        .pa-field-control {
-            border: $border-field-error;
-            background: $color-background-field-error;
-            caret-color: $color-caret-field-control-error;
-
-            &:not(.pa-field-control-filled):not(:active):not(:focus) + .pa-field-label {
-                background: $color-background-field-error;
-            }
-
-            &:not(:disabled):not(:read-only) {
-                &:hover {
-                    border: $border-field-error-hover;
-                }
-
-                &:focus,
-                &:active {
-                    border: $border-field-error-active;
-
-                    & ~ .pa-field-label {
-                        color: $color-text-field-label-error;
-                    }
-                }
-            }
         }
     }
 }

--- a/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
@@ -9,6 +9,7 @@ $rhythm: (
     1.5: ($spacer * 1.5),   //  1.5  unit -  12px -   .75  rem
     2: ($spacer * 2),       //  2    unit -  16px -  1     rem
     3: ($spacer * 3),       //  3    unit -  24px -  1.5   rem
+    3.5: ($spacer * 3.5),   //  3.5  unit -  28px -  1.75   rem
     4: ($spacer * 4),       //  4    unit -  32px -  2     rem
     5: ($spacer * 5),       //  5    unit -  40px -  2.5   rem
     6: ($spacer * 6),       //  6    unit -  48px -  3     rem

--- a/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_spacing.tokens.scss
@@ -1,6 +1,7 @@
 
 // Spacing
 $spacer: .5rem !default;    // 1 unit - 8px - 0.5rem
+/* prettier-ignore */
 $rhythm: (
     0: 0,
     .25: ($spacer * .25),   //   .25 unit -   2px -   .125 rem

--- a/projects/pastanaga-angular/src/styles/theme/_textfield.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_textfield.tokens.scss
@@ -17,6 +17,8 @@ $color-text-field-label-disabled: $color-neutral-light !default;
 $color-text-field-label-error: $color-secondary-regular !default;
 $color-text-field-label-autofilled: $color-autofilled !default;
 
+$scale-text-field-label: 0.8 !default;
+
 //
 // control
 //
@@ -28,10 +30,10 @@ $color-text-field-control-help-regular: $color-neutral-regular !default;
 $color-caret-field-control-active: $color-primary-regular !default;
 $color-caret-field-control-error: $color-secondary-regular !default;
 
-$color-background-field-regular: $color-light-stronger !default;
+$color-background-field-regular: none !default;
 $color-background-field-autofilled: $color-autofilled-background !default;
 $color-background-field-autofilled-transparent: $color-autofilled-background !default;
-$color-background-field-error: $color-light-stronger !default;
+$color-background-field-error: none !default;
 
 //=====================================
 // BORDERS
@@ -39,17 +41,15 @@ $color-background-field-error: $color-light-stronger !default;
 $border-width-regular: 1px !default;
 $border-width-active: 1px !default;
 
-$border-field-regular: $border-width-regular solid $color-neutral-lighter !default;
-$border-field-regular-hover: $border-width-active solid $color-neutral-regular !default;
-$border-field-regular-active: $border-width-active solid $color-primary-regular !default;
+$border-color-field-regular: $color-neutral-lighter !default;
+$border-color-field-hover: $color-neutral-regular !default;
+$border-color-field-active: $color-primary-regular !default;
 
-$border-field-error: $border-width-regular solid $color-secondary-regular !default;
-$border-field-error-hover: $border-width-active solid $color-secondary-regular !default;
-$border-field-error-active: $border-width-active solid $color-secondary-regular !default;
+$border-color-field-error: $color-secondary-regular !default;
 
-$border-field-disabled: $border-width-regular solid $color-neutral-light !default;
-$border-field-readonly: $border-width-regular dashed $color-neutral-light !default;
-$border-field-autofilled: $border-width-regular solid $color-autofilled !default;
+$border-color-field-disabled: $color-neutral-light !default;
+$border-color-field-readonly: $color-neutral-light !default;
+$border-color-field-autofilled: $color-autofilled !default;
 
 $border-radius-field: $border-radius-default !default;
 

--- a/projects/pastanaga-angular/src/styles/theme/_typography.tokens.scss
+++ b/projects/pastanaga-angular/src/styles/theme/_typography.tokens.scss
@@ -12,6 +12,7 @@ $font-weight-bold: 700 !default;
 $base-rem-large: 16px !default;
 
 $font-size-base: 1rem !default;
+/* prettier-ignore */
 $font-size: (
     xxs: ($font-size-base * .625),  // 10px - 0.625 rem
     xs: ($font-size-base * .75),    // 12px - 0.75 rem
@@ -34,8 +35,9 @@ $font-size: (
 @mixin font-size($size) {
     font-size: font-size($size);
 }
-
+/* prettier-ignore */
 $line-height: (
+    xs: ($font-size-base * .875),   // 14px - 0.875 rem
     s:  ($font-size-base * 1),      // 16px - 1 rem
     m:  ($font-size-base * 1.25),   // 20px - 1.25 rem
     l:  ($font-size-base * 1.5),    // 24px - 1.5 rem
@@ -60,7 +62,7 @@ $line-height: (
     font-size: font-size($size);
     line-height: line-height($size);
 }
-
+/* prettier-ignore */
 $letter-spacing: (
     increase-s:     .045rem,    //  0.045rem  -    0.72px
     normal:         0,          //  0


### PR DESCRIPTION

### Breaking changes
- Text fields: 
  - No more background color on text fields by default
  - Improve text field border so label doesn't require a background color and border keep space for the label on active and focus states
  - Replace border-text-field tokens by border-color-text-field token
  - Text field borders management:
      - No more borders on input themselves
      - Add a new `pa-field-container` carrying the classes for all the states (error, disabled, readonly, focus, has content)
      - No more background required on labels to have them displayed over the top border
  - Replace border-text-field tokens by border-color-text-field tokens
  - Use this new style structure on all our fields (input, textarea, select)
  - New `TextFieldDirective` managing label width as well as focus and content states
  - Update label position to be properly aligned with the top border
    - Add `rhythm(3.5)` value in rhythm map
    - Add class `no-internal-label` to remove the label space from the top border when label width is 0

### Improvements
- Add autofilled input example 
- Text fields: 
  - Add `pa-field-icon` class on input icon to prevent style leak 
  - Add `externalLabel` input on `TextFieldDirective` (used by all text fields)
- Toggle: 
  - add `labelOnRight` option
  - improve documentation
