### PR TITLE
Fix popover closing side effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.58.5 (2023-01-02)
+
+### Bugfix
+- **Popover / Popup**: when a popover is set on a button which has an `active` state set programmatically, don't remove the active state when closing the popup [mpellerin42]
+
 # 2.58.4 (2022-12-26)
 
 ### Improvements

--- a/projects/demo/src/app/demo/pages/popover-page/popover-page.component.html
+++ b/projects/demo/src/app/demo/pages/popover-page/popover-page.component.html
@@ -24,6 +24,7 @@
             <pa-button icon="info"
                        #popoverDirective="paPopoverRef"
                        [paPopover]="refreshHelp"
+                       active
                        paPopoverOffset="4px">Refresh</pa-button>
             <pa-button icon="trash"
                        [paPopover]="deleteHelp"

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.58.4",
+    "version": "2.58.5",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -185,8 +185,17 @@ export class PopupDirective implements OnInit, OnChanges, OnDestroy {
     }
 
     private removeActiveStateFromParentButton() {
-        if (this.element.nativeElement.tagName.toLowerCase() === 'pa-button') {
+        if (this.element.nativeElement.tagName.toLowerCase() === 'pa-button' && !this.elementIsSetToActive()) {
             this.renderer.removeClass(this.element.nativeElement.children[0], 'pa-active');
         }
+    }
+
+    /**
+     * Check if element (like pa-button) was set to active programmatically.
+     * @private
+     */
+    private elementIsSetToActive() {
+        const ngActive = this.element.nativeElement.getAttribute('ng-reflect-active');
+        return ngActive === 'true' || ngActive === '';
     }
 }


### PR DESCRIPTION
When a popover is set on a button which has an `active` state set programmatically, don't remove the active state when closing the popup