### PR TITLE
Fix sortable table header icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.58.14 (2023-02-27)
+
+### Bugfix
+
+- **Sortable table**: Fix `table-sortable-header-cell` component to update the icon when `enabled` changes [mpellerin42]
+
 # 2.58.13 (2023-02-09)
 
 ### Bugfix

--- a/package-lock.json
+++ b/package-lock.json
@@ -8042,9 +8042,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-deceiver": {
@@ -22533,9 +22533,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-deceiver": {

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.58.13",
+    "version": "2.58.14",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.ts
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { BreakpointObserver } from '../../breakpoint-observer';
 import { markForCheck } from '../../common';
+import { take } from 'rxjs/operators';
 
 export const SORTABLE_ICON = 'chevron-down';
 export const SORTED_ASCENDING_ICON = 'arrow-down';
@@ -61,13 +62,13 @@ export class TableSortableHeaderCellComponent implements OnChanges {
     constructor(private breakpointObserver: BreakpointObserver, private cdr: ChangeDetectorRef) {}
 
     ngOnChanges(changes: SimpleChanges) {
-        if (changes['active'] || changes['isDescending']) {
+        if (changes['active'] || changes['isDescending'] || changes['enabled']) {
             this.updateIcon();
         }
     }
 
     private updateIcon() {
-        this.breakpointObserver.currentMode.subscribe((mode) => {
+        this.breakpointObserver.currentMode.pipe(take(1)).subscribe((mode) => {
             if (mode === 'mobile') {
                 this.icon = SORTABLE_ICON;
             } else {


### PR DESCRIPTION
- Fix `table-sortable-header-cell` component to update the icon when `enabled` changes
- Bump http-cache-semantics from 4.1.0 to 4.1.1