### PR TITLE
Table improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.59.5 (2023-03-27)
+
+### Improvements
+- **Table** improvements [mpellerin42]
+  - add center option to table cells
+  - tokenize text-transform on header cells
+  - add `ng-content` on `table-sortable-header` allowing the addition of free content on first column. This is specially useful when we want to have a first column made of checkboxes for instance.
+
 # 2.59.4 (2023-03-21)
 
 ### Improvements

--- a/projects/demo/src/app/demo/pages/table-page/table-cell-page/table-cell-page.component.html
+++ b/projects/demo/src/app/demo/pages/table-page/table-cell-page/table-cell-page.component.html
@@ -8,6 +8,9 @@
     <pa-demo-usage>
         <h3>Inputs</h3>
         <dl>
+            <dt>center</dt>
+            <dd>If true, cell's content is horizontally centered. <small>(default: false)</small></dd>
+
             <dt>clickable</dt>
             <dd>If true, hovering the cell will display a pointer cursor. <small>(default: false)</small></dd>
 
@@ -23,17 +26,19 @@
     </pa-demo-usage>
 
     <pa-demo-examples>
-        <pa-table columns="1fr 1fr 1fr 96px">
+        <pa-table columns="1fr 1fr 1fr 1fr 96px">
             <pa-table-header>
                 <pa-table-cell header clickable>Clickable</pa-table-cell>
                 <pa-table-cell header disabled>Disabled</pa-table-cell>
                 <pa-table-cell header noWrap>noWrap</pa-table-cell>
+                <pa-table-cell header center>Center</pa-table-cell>
                 <pa-table-cell-menu header></pa-table-cell-menu>
             </pa-table-header>
             <pa-table-row>
                 <pa-table-cell clickable>Clickable</pa-table-cell>
                 <pa-table-cell disabled>Disabled</pa-table-cell>
                 <pa-table-cell noWrap><span paEllipsisTooltip>noWrap even if super long content going over the limit of the cell, displayed thanks to paEllipsisTooltip</span></pa-table-cell>
+                <pa-table-cell center>–</pa-table-cell>
                 <pa-table-cell-menu><pa-button icon="trash" size="small"></pa-button></pa-table-cell-menu>
             </pa-table-row>
         </pa-table>

--- a/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
+++ b/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
@@ -12,7 +12,8 @@
         <p>Header displaying several columns for tablet or desktop</p>
         <pa-table columns="repeat(4, 1fr)">
             <pa-table-sortable-header [cells]="headerCells"
-                                      (sort)="sortBy($event)"></pa-table-sortable-header>
+                                      (sort)="sortBy($event)">
+            </pa-table-sortable-header>
             <pa-table-row *ngFor="let row of rows">
                 <pa-table-cell>{{row.name}}</pa-table-cell>
                 <pa-table-cell>{{row.source}}</pa-table-cell>
@@ -32,6 +33,25 @@
                     <pa-table-lead-title>{{row.name}}</pa-table-lead-title>
                     <pa-table-lead-description>{{row.source}}</pa-table-lead-description>
                 </pa-table-lead-cell-multi-line>
+            </pa-table-row>
+        </pa-table>
+
+        <p>Header staring with a checkbox column</p>
+        <pa-table columns="40px repeat(4, 1fr)">
+            <pa-table-sortable-header [cells]="headerCells"
+                                      (sort)="sortBy($event)">
+                <pa-table-cell header>
+                    <pa-checkbox></pa-checkbox>
+                </pa-table-cell>
+            </pa-table-sortable-header>
+            <pa-table-row *ngFor="let row of rows">
+                <pa-table-cell>
+                    <pa-checkbox></pa-checkbox>
+                </pa-table-cell>
+                <pa-table-cell>{{row.name}}</pa-table-cell>
+                <pa-table-cell>{{row.source}}</pa-table-cell>
+                <pa-table-cell center>{{row.status}}</pa-table-cell>
+                <pa-table-cell center>{{row.date}}</pa-table-cell>
             </pa-table-row>
         </pa-table>
     </pa-demo-examples>
@@ -56,5 +76,8 @@
 
         <p>Code for the mobile example above:</p>
         <pre><code>{{codeMobile}}</code></pre>
+
+        <p>Code for the table starting with a checkbox column</p>
+        <pre><code>{{codeCheckboxColumn}}</code></pre>
     </pa-demo-code>
 </pa-demo-page>

--- a/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
+++ b/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
@@ -36,7 +36,7 @@
             </pa-table-row>
         </pa-table>
 
-        <p>Header staring with a checkbox column</p>
+        <p>Header starting with a checkbox column</p>
         <pa-table columns="40px repeat(4, 1fr)">
             <pa-table-sortable-header [cells]="headerCells"
                                       (sort)="sortBy($event)">

--- a/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
+++ b/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.html
@@ -10,17 +10,18 @@
 
     <pa-demo-examples>
         <p>Header displaying several columns for tablet or desktop</p>
-        <pa-table columns="repeat(3, 1fr)">
+        <pa-table columns="repeat(4, 1fr)">
             <pa-table-sortable-header [cells]="headerCells"
                                       (sort)="sortBy($event)"></pa-table-sortable-header>
             <pa-table-row *ngFor="let row of rows">
                 <pa-table-cell>{{row.name}}</pa-table-cell>
                 <pa-table-cell>{{row.source}}</pa-table-cell>
-                <pa-table-cell>{{row.status}}</pa-table-cell>
+                <pa-table-cell center>{{row.status}}</pa-table-cell>
+                <pa-table-cell center>{{row.date}}</pa-table-cell>
             </pa-table-row>
         </pa-table>
 
-        <p>Header displaying only one the active for mobile</p>
+        <p>Header displaying only the active one on mobile mode</p>
         <pa-table>
             <pa-table-sortable-header mode="mobile"
                                       [cells]="headerCells"

--- a/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.ts
+++ b/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.ts
@@ -31,6 +31,22 @@ export class TableSortableHeaderPageComponent {
     </pa-table-row>
 </pa-table>`;
 
+    codeCheckboxColumn = `<pa-table columns="40px repeat(4, 1fr)">
+    <pa-table-sortable-header [cells]="headerCells"
+                              (sort)="sortBy($event)">
+        <pa-table-cell header>
+            <pa-checkbox></pa-checkbox>
+        </pa-table-cell>
+    </pa-table-sortable-header>
+    <pa-table-row *ngFor="let row of rows">
+        <pa-table-cell><pa-checkbox></pa-checkbox></pa-table-cell>
+        <pa-table-cell>{{row.name}}</pa-table-cell>
+        <pa-table-cell>{{row.source}}</pa-table-cell>
+        <pa-table-cell center>{{row.status}}</pa-table-cell>
+        <pa-table-cell center>{{row.date}}</pa-table-cell>
+    </pa-table-row>
+</pa-table>`;
+
     headerCells: HeaderCell[] = [
         new SortableHeaderCell({ id: 'name', label: 'Name', active: true }),
         new SortableHeaderCell({ id: 'source', label: 'Source' }),

--- a/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.ts
+++ b/projects/demo/src/app/demo/pages/table-page/table-sortable-header-page/table-sortable-header-page.component.ts
@@ -7,13 +7,14 @@ import { HeaderCell, SortableHeaderCell } from '@guillotinaweb/pastanaga-angular
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TableSortableHeaderPageComponent {
-    codeDesktop = `<pa-table columns="repeat(3, 1fr)">
+    codeDesktop = `<pa-table columns="repeat(4, 1fr)">
     <pa-table-sortable-header [cells]="headerCells"
                               (sort)="sortBy($event)"></pa-table-sortable-header>
     <pa-table-row *ngFor="let row of rows">
         <pa-table-cell>{{row.name}}</pa-table-cell>
         <pa-table-cell>{{row.source}}</pa-table-cell>
-        <pa-table-cell>{{row.status}}</pa-table-cell>
+        <pa-table-cell center>{{row.status}}</pa-table-cell>
+        <pa-table-cell center>{{row.date}}</pa-table-cell>
     </pa-table-row>
 </pa-table>`;
 
@@ -33,13 +34,15 @@ export class TableSortableHeaderPageComponent {
     headerCells: HeaderCell[] = [
         new SortableHeaderCell({ id: 'name', label: 'Name', active: true }),
         new SortableHeaderCell({ id: 'source', label: 'Source' }),
-        new HeaderCell({ id: 'status', label: 'Status' }),
+        new HeaderCell({ id: 'status', label: 'Status', centered: true }),
+        new SortableHeaderCell({ id: 'date', label: 'Date', centered: true }),
     ];
 
-    rows: { name: string; source: string; status: string }[] = [
-        { name: 'Aurora', source: 'Source 1', status: 'Sleeping' },
-        { name: 'Ariel', source: 'Source 2', status: 'Swimming' },
-        { name: 'Mulan', source: 'Source 3', status: 'Fighting' },
+    rows: { name: string; source: string; status: string; date: string }[] = [
+        { name: 'Aurora', source: 'Source 1', status: 'Sleeping', date: '1959' },
+        { name: 'Ariel', source: 'Source 2', status: 'Swimming', date: '1989' },
+        { name: 'Elsa', source: 'Source 3', status: '–', date: '2013' },
+        { name: 'Mulan', source: 'Source 4', status: 'Fighting', date: '1998' },
     ];
 
     sortBy(column: HeaderCell) {

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.59.4",
+    "version": "2.59.5",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/table/table-cell/table-cell.component.html
+++ b/projects/pastanaga-angular/src/lib/table/table-cell/table-cell.component.html
@@ -1,9 +1,12 @@
-<div [class.pa-table-grid--cell]="!header"
-     [class.pa-table-grid--header]="header"
-     [class.pa-clickable]="clickable"
-     [class.pa-disabled]="disabled"
-     [class.pa-no-wrap]="noWrap"
-     paFocusable
-     [paFocusDisabled]="!clickable">
+<div
+    [class.pa-table-grid--cell]="!header"
+    [class.pa-table-grid--header]="header"
+    [class.pa-clickable]="clickable"
+    [class.pa-disabled]="disabled"
+    [class.pa-no-wrap]="noWrap"
+    [class.pa-center]="center"
+    paFocusable
+    [paFocusDisabled]="!clickable"
+>
     <ng-content></ng-content>
 </div>

--- a/projects/pastanaga-angular/src/lib/table/table-cell/table-cell.component.ts
+++ b/projects/pastanaga-angular/src/lib/table/table-cell/table-cell.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ViewEncapsulation, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 
 @Component({
@@ -40,8 +40,17 @@ export class TableCellComponent {
         this._noWrap = coerceBooleanProperty(value);
     }
 
+    @Input()
+    get center(): boolean {
+        return this._center;
+    }
+    set center(value: any) {
+        this._center = coerceBooleanProperty(value);
+    }
+
     private _noWrap = false;
     private _disabled = false;
     private _header = false;
     private _clickable = false;
+    private _center = false;
 }

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.html
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.html
@@ -1,10 +1,6 @@
-<div #cell
-     class="pa-table-grid--header clickable"
-     (click)="sort.emit()"
-     paFocusable>
-
-    <button type="button"
-            [class.pa-enabled]="enabled"
-            [class.pa-active]="active"
-            paFocusable><ng-content></ng-content> <pa-icon *ngIf="icon" [name]="icon" size="small"></pa-icon></button>
+<div #cell class="pa-table-grid--header clickable" [class.pa-center]="center" (click)="sort.emit()" paFocusable>
+    <button type="button" [class.pa-enabled]="enabled" [class.pa-active]="active" paFocusable>
+        <ng-content></ng-content>
+        <pa-icon *ngIf="icon" [name]="icon" size="small"></pa-icon>
+    </button>
 </div>

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.scss
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.scss
@@ -10,7 +10,7 @@ button {
     padding: 0;
     margin: 0;
     font-weight: $font-weight-bold;
-    text-transform: uppercase;
+    text-transform: $text-transform-table-header;
 
     &:active,
     &.pa-active {
@@ -28,9 +28,11 @@ button {
 
         &.pa-enabled pa-icon {
             opacity: 1;
-            transition: transform ease-in-out .3s;
+            transition: transform ease-in-out 0.3s;
         }
-        &:hover, &:active, &.pa-keyboard-focus {
+        &:hover,
+        &:active,
+        &.pa-keyboard-focus {
             cursor: pointer;
             color: $color-dark-stronger;
 

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.ts
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header-cell/table-sortable-header-cell.component.ts
@@ -49,6 +49,13 @@ export class TableSortableHeaderCellComponent implements OnChanges {
         return this._isDescending;
     }
 
+    @Input()
+    get center(): boolean {
+        return this._center;
+    }
+    set center(value: any) {
+        this._center = coerceBooleanProperty(value);
+    }
     @Output() sort = new EventEmitter();
 
     @ViewChild('cell', { read: ElementRef }) cellElement?: ElementRef;
@@ -58,6 +65,7 @@ export class TableSortableHeaderCellComponent implements OnChanges {
     private _enabled = false;
     private _active = false;
     private _isDescending = false;
+    private _center = false;
 
     constructor(private breakpointObserver: BreakpointObserver, private cdr: ChangeDetectorRef) {}
 

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header/table-sortable-header.component.html
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header/table-sortable-header.component.html
@@ -1,42 +1,43 @@
 <ng-container *ngIf="mode !== 'mobile'; else mobileHeader">
     <ng-container *ngFor="let cell of cells">
-        <pa-table-sortable-header-cell *ngIf="cell.sortable; else basicCell"
-                                       [enabled]="cell.active"
-                                       [isDescending]="cell.descending"
-                                       (sort)="sortBy(cell.id)"
-        >{{cell.label | translate}}</pa-table-sortable-header-cell>
+        <pa-table-sortable-header-cell
+            *ngIf="cell.sortable; else basicCell"
+            [enabled]="cell.active"
+            [isDescending]="cell.descending"
+            [center]="cell.centered"
+            (sort)="sortBy(cell.id)"
+            >{{ cell.label | translate }}</pa-table-sortable-header-cell
+        >
 
         <ng-template #basicCell>
-            <pa-table-cell header>{{cell.label | translate}}</pa-table-cell>
+            <pa-table-cell header [center]="cell.centered">{{ cell.label | translate }}</pa-table-cell>
         </ng-template>
     </ng-container>
 </ng-container>
 <pa-table-cell-menu header *ngIf="menuColumn"></pa-table-cell-menu>
 
 <ng-template #mobileHeader>
-    <pa-table-sortable-header-cell *ngIf="mobileCell?.sortable; else basicCell"
-                                   #mobileCellContainer
-                                   [active]="sortMenuOpen"
-                                   [paPopup]="sortMenu"
-                                   [popupPosition]="sortMenuPosition"
-    >{{mobileCell?.label | translate}}
+    <pa-table-sortable-header-cell
+        *ngIf="mobileCell?.sortable; else basicCell"
+        #mobileCellContainer
+        [active]="sortMenuOpen"
+        [paPopup]="sortMenu"
+        [popupPosition]="sortMenuPosition"
+        >{{ mobileCell?.label | translate }}
     </pa-table-sortable-header-cell>
 
     <ng-template #basicCell>
-        <pa-table-cell header>{{mobileCell?.label | translate}}</pa-table-cell>
+        <pa-table-cell header [center]="mobileCell?.centered">{{ mobileCell?.label | translate }}</pa-table-cell>
     </ng-template>
 
-    <pa-dropdown #sortMenu
-                 (onOpen)="sortMenuOpen = true"
-                 (onClose)="sortMenuOpen = false">
-        <pa-option-header>{{'pastanaga.sort-by' | translate }}</pa-option-header>
-        <pa-option *ngFor="let cell of sortableCells"
-                   [icon]="!cell.active ? 'no-icon' : cell.descending ? 'arrow-up' : 'arrow-down'"
-                   [selected]="cell.active"
-                   (selectOption)="sortBy(cell.id)"
-        >{{cell.label | translate}}</pa-option>
+    <pa-dropdown #sortMenu (onOpen)="sortMenuOpen = true" (onClose)="sortMenuOpen = false">
+        <pa-option-header>{{ 'pastanaga.sort-by' | translate }}</pa-option-header>
+        <pa-option
+            *ngFor="let cell of sortableCells"
+            [icon]="!cell.active ? 'no-icon' : cell.descending ? 'arrow-up' : 'arrow-down'"
+            [selected]="cell.active"
+            (selectOption)="sortBy(cell.id)"
+            >{{ cell.label | translate }}</pa-option
+        >
     </pa-dropdown>
 </ng-template>
-
-
-

--- a/projects/pastanaga-angular/src/lib/table/table-sortable-header/table-sortable-header.component.html
+++ b/projects/pastanaga-angular/src/lib/table/table-sortable-header/table-sortable-header.component.html
@@ -1,3 +1,4 @@
+<ng-content></ng-content>
 <ng-container *ngIf="mode !== 'mobile'; else mobileHeader">
     <ng-container *ngFor="let cell of cells">
         <pa-table-sortable-header-cell

--- a/projects/pastanaga-angular/src/lib/table/table.component.ts
+++ b/projects/pastanaga-angular/src/lib/table/table.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
 import { DomSanitizer } from '@angular/platform-browser';
 

--- a/projects/pastanaga-angular/src/lib/table/table.models.ts
+++ b/projects/pastanaga-angular/src/lib/table/table.models.ts
@@ -6,6 +6,7 @@ export interface IHeaderCell {
     active?: boolean;
     sortable?: boolean;
     descending?: boolean;
+    centered?: boolean;
 }
 
 export class HeaderCell {
@@ -14,6 +15,7 @@ export class HeaderCell {
     sortable: boolean;
     active: boolean;
     descending: boolean;
+    centered: boolean;
 
     constructor(data: IHeaderCell) {
         this.id = data.id;
@@ -21,6 +23,7 @@ export class HeaderCell {
         this.sortable = coerceBooleanProperty(data.sortable);
         this.active = coerceBooleanProperty(data.active);
         this.descending = coerceBooleanProperty(data.descending);
+        this.centered = coerceBooleanProperty(data.centered);
     }
 }
 

--- a/projects/pastanaga-angular/src/styles/components/_tables.scss
+++ b/projects/pastanaga-angular/src/styles/components/_tables.scss
@@ -99,6 +99,10 @@
     display: flex;
     align-items: center;
     padding: 0 rhythm(1);
+
+    &.pa-center {
+        justify-content: center;
+    }
 }
 .pa-table-grid--cell {
     background: $color-background-table-row;
@@ -115,6 +119,9 @@
     }
     &.pa-keyboard-focus {
         box-shadow: inset $shadow-focus !important;
+    }
+    &.pa-center {
+        justify-content: center;
     }
 }
 


### PR DESCRIPTION
  - add center option to table cells
  - tokenize text-transform on header cells
  - add `ng-content` on `table-sortable-header` allowing the addition of free content on first column. This is specially useful when we want to have a first column made of checkboxes for instance.