### PR TITLE
Replace deprecated ComponentFactoryResolver + Toast improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.61.5 (2023-05-15)
+
+### Improvements
+
+- Replace deprecated `ComponentFactoryResolver` in `ModalService`, `ToastService` and `TooltipDirective` [mpellerin42]
+- **Toast**: [mpellerin42]
+  - Prevent toast container to capture clicks 
+  - Add ability to close toasts by pressing escape
+
 # 2.61.4 (2023-04-27)
 
 ### Bug fixes

--- a/projects/demo/src/app/demo/pages/tooltip-page/tooltip-page.component.html
+++ b/projects/demo/src/app/demo/pages/tooltip-page/tooltip-page.component.html
@@ -3,10 +3,13 @@
     <pa-demo-description>Directive that adds tooltip to any element.</pa-demo-description>
 
     <pa-demo-examples>
-        <pa-button paTooltip="This button has action tooltip">Hover me</pa-button>
-        <pa-button paTooltip="Close" icon="cross">Close</pa-button>
-        <pa-button paTooltip="This button has system tooltip" paTooltipType="system">Following mouse</pa-button>
-        <pa-button paTooltip="This tooltip has offset" [paTooltipOffset]="-80">With -80px offset</pa-button>
+        <div style="display: flex; align-items: center; gap: 16px">
+            <pa-button paTooltip="This button has action tooltip">Hover me</pa-button>
+            <pa-button paTooltip="Close" icon="cross">Close</pa-button>
+            <pa-button paTooltip="This button has system tooltip" paTooltipType="system">Following mouse</pa-button>
+            <pa-button paTooltip="This tooltip has offset" [paTooltipOffset]="-80">With -80px offset</pa-button>
+        </div>
+
     </pa-demo-examples>
 
     <pa-demo-usage>

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.61.4",
+    "version": "2.61.5",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/modal/modal.service.ts
+++ b/projects/pastanaga-angular/src/lib/modal/modal.service.ts
@@ -1,9 +1,9 @@
 import {
     ApplicationRef,
-    ComponentFactoryResolver,
     ComponentRef,
+    createComponent,
+    createEnvironmentInjector,
     Injectable,
-    Injector,
     NgZone,
     Type,
 } from '@angular/core';
@@ -20,12 +20,7 @@ export class ModalService {
 
     modals: ComponentRef<any>[] = [];
 
-    constructor(
-        private componentFactoryResolver: ComponentFactoryResolver,
-        private appRef: ApplicationRef,
-        private injector: Injector,
-        private zone: NgZone,
-    ) {}
+    constructor(private appRef: ApplicationRef, private zone: NgZone) {}
 
     openConfirm(data: ConfirmationData): ModalRef {
         return this.openModal(ConfirmationDialogComponent, new ModalConfig<ConfirmationData>({ data }));
@@ -37,18 +32,18 @@ export class ModalService {
         ref.onDismiss.subscribe(() => this.closeModal(ref));
 
         // instantiate injector
-        const injector = Injector.create({
-            providers: [
+        const injector = createEnvironmentInjector(
+            [
                 {
                     provide: ModalRef,
                     useValue: ref,
                 },
             ],
-            parent: this.injector,
-        });
+            this.appRef.injector,
+        );
 
         // instantiate modal component
-        const modalComponentRef = this.componentFactoryResolver.resolveComponentFactory(component).create(injector);
+        const modalComponentRef = createComponent(component, { environmentInjector: injector });
         this.appRef.attachView(modalComponentRef.hostView);
         document.body.appendChild(modalComponentRef.location.nativeElement);
 

--- a/projects/pastanaga-angular/src/lib/toast/toast.service.ts
+++ b/projects/pastanaga-angular/src/lib/toast/toast.service.ts
@@ -49,7 +49,6 @@ export class ToastService {
     }
 
     open(message: string, type: ToastType, config?: ToastConfig): ComponentRef<ToastComponent> {
-        const mainNow = Date.now();
         const id = `pa-toast-${nextId++}`;
         const toast: ComponentRef<ToastComponent> = this.createToast(id, message, type, config);
         const toastRefs = {

--- a/projects/pastanaga-angular/src/lib/toast/toast.service.ts
+++ b/projects/pastanaga-angular/src/lib/toast/toast.service.ts
@@ -1,12 +1,4 @@
-import {
-    ApplicationRef,
-    ComponentFactoryResolver,
-    ComponentRef,
-    Injectable,
-    Injector,
-    Renderer2,
-    RendererFactory2,
-} from '@angular/core';
+import { ApplicationRef, ComponentRef, createComponent, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { ToastComponent } from './toast.component';
 import { ToastConfig, ToastType } from './toast.model';
 
@@ -29,12 +21,7 @@ export class ToastService {
         return this._renderer;
     }
 
-    constructor(
-        private resolver: ComponentFactoryResolver,
-        private rendererFactory: RendererFactory2,
-        private appRef: ApplicationRef,
-        private injector: Injector,
-    ) {
+    constructor(private rendererFactory: RendererFactory2, private appRef: ApplicationRef) {
         this._renderer = rendererFactory.createRenderer(null, null);
     }
 
@@ -67,9 +54,7 @@ export class ToastService {
     }
 
     private createToast(id: string, message: string, type: ToastType, config?: ToastConfig) {
-        const componentFactory = this.resolver.resolveComponentFactory(ToastComponent);
-
-        const componentRef = componentFactory.create(this.injector);
+        const componentRef = createComponent(ToastComponent, { environmentInjector: this.appRef.injector });
         componentRef.instance.id = id;
         componentRef.instance.message = message;
         componentRef.instance.type = type;

--- a/projects/pastanaga-angular/src/lib/toast/toast.service.ts
+++ b/projects/pastanaga-angular/src/lib/toast/toast.service.ts
@@ -1,6 +1,7 @@
 import { ApplicationRef, ComponentRef, createComponent, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { ToastComponent } from './toast.component';
 import { ToastConfig, ToastType } from './toast.model';
+import { Keys } from '../common';
 
 let nextId = 0;
 
@@ -8,7 +9,13 @@ let nextId = 0;
 export class ToastService {
     private readonly _renderer: Renderer2;
     private _toastContainer?: HTMLElement;
-    private _toastMap: Map<string, ComponentRef<ToastComponent>> = new Map();
+    private _toastMap: Map<
+        string,
+        {
+            component: ComponentRef<ToastComponent>;
+            unListeners: (() => void)[];
+        }
+    > = new Map();
 
     get toastContainer(): HTMLElement {
         if (!this._toastContainer) {
@@ -42,14 +49,26 @@ export class ToastService {
     }
 
     open(message: string, type: ToastType, config?: ToastConfig): ComponentRef<ToastComponent> {
+        const mainNow = Date.now();
         const id = `pa-toast-${nextId++}`;
         const toast: ComponentRef<ToastComponent> = this.createToast(id, message, type, config);
+        const toastRefs = {
+            component: toast,
+            unListeners: [
+                this._renderer.listen(document, 'keyup', (event: KeyboardEvent) => {
+                    if (event.key === Keys.esc) {
+                        this.removeToast(id);
+                    }
+                }),
+            ],
+        };
 
         this.appRef.attachView(toast.hostView);
-        this._toastMap.set(id, toast);
+        this._toastMap.set(id, toastRefs);
 
         this._renderer.setAttribute(toast.location.nativeElement, 'role', 'alert');
         this._renderer.appendChild(this.toastContainer, toast.location.nativeElement);
+
         return toast;
     }
 
@@ -79,8 +98,9 @@ export class ToastService {
         if (!ref) {
             return;
         }
-        this.appRef.detachView(ref.hostView);
-        ref.destroy();
+        ref.unListeners.forEach((unListen) => unListen());
+        this.appRef.detachView(ref.component.hostView);
+        ref.component.destroy();
         this._toastMap.delete(id);
         if (!this._toastMap.size) {
             this.removeContainer();

--- a/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
@@ -1,13 +1,4 @@
-import {
-    ComponentFactoryResolver,
-    ComponentRef,
-    Directive,
-    ElementRef,
-    HostListener,
-    Input,
-    Renderer2,
-    ViewContainerRef,
-} from '@angular/core';
+import { ComponentRef, Directive, ElementRef, HostListener, Input, Renderer2, ViewContainerRef } from '@angular/core';
 import { TooltipComponent } from './tooltip.component';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import { markForCheck } from '../common';
@@ -38,12 +29,7 @@ export class TooltipDirective {
 
     private component?: ComponentRef<TooltipComponent>;
 
-    constructor(
-        private element: ElementRef,
-        private viewContainerRef: ViewContainerRef,
-        private resolver: ComponentFactoryResolver,
-        private renderer: Renderer2,
-    ) {}
+    constructor(private element: ElementRef, private viewContainerRef: ViewContainerRef, private renderer: Renderer2) {}
 
     @HostListener('focusin', ['$event'])
     focus(event: MouseEvent | any) {
@@ -90,8 +76,8 @@ export class TooltipDirective {
     createTooltip(x: number, y: number, width: number, height: number) {
         this.id = `pa-tooltip-${nextId++}`;
         this.element.nativeElement.setAttribute('aria-describedby', this.id);
-        const factory = this.resolver.resolveComponentFactory(TooltipComponent);
-        this.component = this.viewContainerRef.createComponent(factory);
+
+        this.component = this.viewContainerRef.createComponent(TooltipComponent);
         this.component.instance.id = this.id;
         this.component.instance.text = this.text;
         this.component.instance.isAction = this.type === ACTION;

--- a/projects/pastanaga-angular/src/styles/components/_toast.scss
+++ b/projects/pastanaga-angular/src/styles/components/_toast.scss
@@ -1,10 +1,9 @@
 @import '../variables';
 .pa-toast-container {
     content: '';
+    cursor: default;
     position: fixed;
     top: 0;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
+    transform: translateX(calc(100vw / 2 - 100%/2));
     z-index: $z-index-toast;
 }


### PR DESCRIPTION
- Fix https://github.com/plone/pastanaga-angular/issues/600 : Replace deprecated ComponentFactoryResolver
- Toast improvements:   
  - Prevent toast container to capture clicks 
  - Add ability to close toasts by pressing escape