### PR TITLE
Cache management on glyphs sprite + fix popup position for container-type: size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Icons**: New `SPRITE_CACHE_VERSION` injection token allowing to manage the cache version of svg sprite
 
+### Bugfix
+
+- **Popup**: Fix popup position when one of the popup’s parent has `container-type: size`
+
 # 2.64.2 (2023-12-12)
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.64.3 (2023-12-19)
+
+### Improvements
+
+- **Icons**: New `SPRITE_CACHE_VERSION` injection token allowing to manage the cache version of svg sprite
+
 # 2.64.2 (2023-12-12)
 
 ### Bugfix

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
@@ -31,119 +31,247 @@
 
   <pa-demo-examples>
     <div>
-      <pa-dropdown stayVisible>
-        <pa-option-header>Dropdown header</pa-option-header>
-        <pa-option
-          icon="image"
-          id="menu-item-1"
-          (selectOption)="onSelect($event)">
-          Icon on left
-        </pa-option>
-        <pa-option
-          disabled
-          iconOnRight
-          icon="info"
-          id="menu-item-2"
-          (selectOption)="onSelect($event)">
-          Icon on right & disabled
-        </pa-option>
-        <pa-option
-          icon="folder"
-          id="menu-item-3"
-          description="Very long description which has an ellipsis and a tooltip allowing to read it all."
-          (selectOption)="onSelect($event)">
-          Icon on left
-        </pa-option>
-        <pa-separator></pa-separator>
-        <pa-option
-          icon="trash"
-          destructive
-          id="menu-item-destructive"
-          (selectOption)="onSelect($event)">
-          Icon on left & destructive item
-        </pa-option>
-      </pa-dropdown>
-    </div>
-
-    <div>
-      <pa-button
-        icon="more-horizontal"
-        size="small"
-        [paPopup]="contextualMenu"></pa-button>
-
-      <pa-dropdown #contextualMenu>
-        <pa-option (selectOption)="onSelect($event)">Dropdown item 1</pa-option>
-        <pa-option (selectOption)="onSelect($event)">Dropdown item 2</pa-option>
-        <pa-option (selectOption)="onSelect($event)">Dropdown item 3</pa-option>
-        <pa-separator></pa-separator>
-        <pa-option
-          destructive
-          dontCloseOnSelect
-          (selectOption)="onSelect($event)">
-          Dropdown item destructive
-        </pa-option>
-      </pa-dropdown>
-    </div>
-
-    <div>
-      <pa-button
-        [paPopup]="level1"
-        sameWidth>
-        <div style="display: flex; align-items: center">
-          Multi-level dropdown
-          <pa-icon name="chevron-down"></pa-icon>
+      <p><strong>Normal container</strong></p>
+      <div style="margin-bottom: 32px; display: flex; gap: 16px">
+        <div>
+          <pa-dropdown stayVisible>
+            <pa-option-header>Dropdown header</pa-option-header>
+            <pa-option
+              icon="image"
+              id="menu-item-01"
+              (selectOption)="onSelect($event)">
+              Icon on left
+            </pa-option>
+            <pa-option
+              disabled
+              iconOnRight
+              icon="info"
+              id="menu-item-02"
+              (selectOption)="onSelect($event)">
+              Icon on right & disabled
+            </pa-option>
+            <pa-option
+              icon="folder"
+              id="menu-item-03"
+              description="Very long description which has an ellipsis and a tooltip allowing to read it all."
+              (selectOption)="onSelect($event)">
+              Icon on left
+            </pa-option>
+            <pa-separator></pa-separator>
+            <pa-option
+              icon="trash"
+              destructive
+              id="menu-item-destructive-0"
+              (selectOption)="onSelect($event)">
+              Icon on left & destructive item
+            </pa-option>
+          </pa-dropdown>
         </div>
-      </pa-button>
 
-      <pa-dropdown
-        #level1
-        [companionElement]="level2Element?.nativeElement">
-        <pa-option
-          icon="chevron-right"
-          iconOnRight
-          dontCloseOnSelect
-          popupOnRight
-          [paPopup]="level2"
-          [popupVerticalOffset]="-40"
-          [selected]="level1Open === 'jedi'"
-          (selectOption)="onLevel1Selection('jedi')">
-          Jedi
-        </pa-option>
-        <pa-option
-          icon="chevron-right"
-          iconOnRight
-          dontCloseOnSelect
-          popupOnRight
-          [paPopup]="level2"
-          [popupVerticalOffset]="-40"
-          [selected]="level1Open === 'rebels'"
-          (selectOption)="onLevel1Selection('rebels')">
-          Rebels
-        </pa-option>
-        <pa-option
-          icon="chevron-right"
-          iconOnRight
-          dontCloseOnSelect
-          popupOnRight
-          [paPopup]="level2"
-          [popupVerticalOffset]="-40"
-          [selected]="level1Open === 'sith'"
-          (selectOption)="onLevel1Selection('sith')">
-          Sith
-        </pa-option>
-      </pa-dropdown>
+        <div>
+          <pa-button
+            icon="more-horizontal"
+            size="small"
+            [paPopup]="contextualMenu"></pa-button>
 
-      <pa-dropdown
-        #level2
-        keepOthersOpen>
-        @for (option of level2Options; track option.label) {
-          <pa-option
-            dontCloseOnSelect
-            (selectOption)="updateCheckbox(option, $event)">
-            <pa-checkbox [(value)]="option.checked">{{ option.label }}</pa-checkbox>
-          </pa-option>
-        }
-      </pa-dropdown>
+          <pa-dropdown #contextualMenu>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 1</pa-option>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 2</pa-option>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 3</pa-option>
+            <pa-separator></pa-separator>
+            <pa-option
+              destructive
+              dontCloseOnSelect
+              (selectOption)="onSelect($event)">
+              Dropdown item destructive
+            </pa-option>
+          </pa-dropdown>
+        </div>
+
+        <div>
+          <pa-button
+            [paPopup]="level1"
+            sameWidth>
+            <div style="display: flex; align-items: center">
+              Multi-level dropdown
+              <pa-icon name="chevron-down"></pa-icon>
+            </div>
+          </pa-button>
+
+          <pa-dropdown
+            #level1
+            [companionElement]="level2Element?.nativeElement">
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level2"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'jedi'"
+              (selectOption)="onLevel1Selection('jedi')">
+              Jedi
+            </pa-option>
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level2"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'rebels'"
+              (selectOption)="onLevel1Selection('rebels')">
+              Rebels
+            </pa-option>
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level2"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'sith'"
+              (selectOption)="onLevel1Selection('sith')">
+              Sith
+            </pa-option>
+          </pa-dropdown>
+
+          <pa-dropdown
+            #level2
+            keepOthersOpen>
+            @for (option of level2Options; track option.label) {
+              <pa-option
+                dontCloseOnSelect
+                (selectOption)="updateCheckbox(option, $event)">
+                <pa-checkbox [(value)]="option.checked">{{ option.label }}</pa-checkbox>
+              </pa-option>
+            }
+          </pa-dropdown>
+        </div>
+      </div>
+      <p>
+        <strong>
+          Container with
+          <code>container-type: size</code>
+        </strong>
+      </p>
+      <div style="container-type: size; width: fit-content; display: flex; gap: 16px; height: 200px">
+        <div>
+          <pa-dropdown stayVisible>
+            <pa-option-header>Dropdown header</pa-option-header>
+            <pa-option
+              icon="image"
+              id="menu-item-1"
+              (selectOption)="onSelect($event)">
+              Icon on left
+            </pa-option>
+            <pa-option
+              disabled
+              iconOnRight
+              icon="info"
+              id="menu-item-2"
+              (selectOption)="onSelect($event)">
+              Icon on right & disabled
+            </pa-option>
+            <pa-option
+              icon="folder"
+              id="menu-item-3"
+              description="Very long description which has an ellipsis and a tooltip allowing to read it all."
+              (selectOption)="onSelect($event)">
+              Icon on left
+            </pa-option>
+            <pa-separator></pa-separator>
+            <pa-option
+              icon="trash"
+              destructive
+              id="menu-item-destructive"
+              (selectOption)="onSelect($event)">
+              Icon on left & destructive item
+            </pa-option>
+          </pa-dropdown>
+        </div>
+
+        <div>
+          <pa-button
+            icon="more-horizontal"
+            size="small"
+            [paPopup]="contextualMenu0"></pa-button>
+
+          <pa-dropdown #contextualMenu0>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 1</pa-option>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 2</pa-option>
+            <pa-option (selectOption)="onSelect($event)">Dropdown item 3</pa-option>
+            <pa-separator></pa-separator>
+            <pa-option
+              destructive
+              dontCloseOnSelect
+              (selectOption)="onSelect($event)">
+              Dropdown item destructive
+            </pa-option>
+          </pa-dropdown>
+        </div>
+
+        <div>
+          <pa-button
+            [paPopup]="level01"
+            sameWidth>
+            <div style="display: flex; align-items: center">
+              Multi-level dropdown
+              <pa-icon name="chevron-down"></pa-icon>
+            </div>
+          </pa-button>
+
+          <pa-dropdown
+            #level01
+            [companionElement]="level2Element?.nativeElement">
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level02"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'jedi'"
+              (selectOption)="onLevel1Selection('jedi')">
+              Jedi
+            </pa-option>
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level02"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'rebels'"
+              (selectOption)="onLevel1Selection('rebels')">
+              Rebels
+            </pa-option>
+            <pa-option
+              icon="chevron-right"
+              iconOnRight
+              dontCloseOnSelect
+              popupOnRight
+              [paPopup]="level02"
+              [popupVerticalOffset]="-40"
+              [selected]="level1Open === 'sith'"
+              (selectOption)="onLevel1Selection('sith')">
+              Sith
+            </pa-option>
+          </pa-dropdown>
+
+          <pa-dropdown
+            #level02
+            keepOthersOpen>
+            @for (option of level2Options; track option.label) {
+              <pa-option
+                dontCloseOnSelect
+                (selectOption)="updateCheckbox(option, $event)">
+                <pa-checkbox [(value)]="option.checked">{{ option.label }}</pa-checkbox>
+              </pa-option>
+            }
+          </pa-dropdown>
+        </div>
+      </div>
     </div>
   </pa-demo-examples>
 

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
@@ -37,7 +37,7 @@ export class DropdownPageComponent {
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               popupOnRight
+               alignPopupOnLeft
                [paPopup]="level2"
                [popupVerticalOffset]="-40"
                [selected]="level1Open === 'jedi'"
@@ -45,7 +45,7 @@ export class DropdownPageComponent {
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               popupOnRight
+               alignPopupOnLeft
                [paPopup]="level2"
                [popupVerticalOffset]="-40"
                [selected]="level1Open === 'rebels'"
@@ -53,7 +53,7 @@ export class DropdownPageComponent {
     <pa-option icon="chevron-right"
                iconOnRight
                dontCloseOnSelect
-               popupOnRight
+               alignPopupOnLeft
                [paPopup]="level2"
                [popupVerticalOffset]="-40"
                [selected]="level1Open === 'sith'"

--- a/projects/demo/src/app/demo/pages/icon-page/base-icon-page.component.ts
+++ b/projects/demo/src/app/demo/pages/icon-page/base-icon-page.component.ts
@@ -7,13 +7,19 @@ export class BaseIconPageComponent {
   selectedBackground = 'none';
   _selectedColor?: string;
   _selectedBackground?: string;
-  nameResolvedExample = 'assets/icons-sprite.svg#${name}';
+  nameResolvedExample = 'assets/glyphs-sprite.svg#${name}';
   codeExample = `<pa-icon [name]="iconName" [size]="selectedSize" [color]="selectedColor" [background]="selectedBackground"></pa-icon>
 
 <pa-icon name="heart"></pa-icon>
 
 <pa-icon path="./assets/dialog/heart-band.png"></pa-icon>
 `;
+
+  cacheVersionExample = `providers: [{
+  provide: SPRITE_CACHE_VERSION,
+  useFactory: (config: YourConfigurationService) => config.getVersion(),
+  deps: [BackendConfigurationService],
+}]`;
 
   updateColor(value: string) {
     this._selectedColor = value === 'none' ? 'inherit' : value;

--- a/projects/demo/src/app/demo/pages/icon-page/icon-page.component.html
+++ b/projects/demo/src/app/demo/pages/icon-page/icon-page.component.html
@@ -5,7 +5,11 @@
     <p>
       Pastanaga provides a component
       <code>pa-icon</code>
-      allowing to display an icon by its name from the glyph-sprite, or any image by their path.
+      allowing to display an icon from the
+      <code>glyph-sprite</code>
+      by using the icon name.
+      <code>pa-icon</code>
+      can also be used to display any image by providing their path.
     </p>
     <p>
       Icons are inheriting their colors from the text color. Overriding an icon color is as simple as adding a css class
@@ -26,6 +30,10 @@
       <li>cross: used in chip-closeable, modal-advanced and side-nav components</li>
       <li>more-horizontal: used in avatar-pile component</li>
     </ul>
+    <p>
+      Check the code section at the bottom of the page for an example explaining how to manage the cache on the glyphs
+      sprite.
+    </p>
     <p>Below is the list of all icons available in Pastanaga:</p>
   </pa-demo-description>
 
@@ -145,6 +153,15 @@
   </pa-demo-usage>
 
   <pa-demo-code>
+    Basic examples:
     <pre><code>{{codeExample}}</code></pre>
+
+    By default, there is no suffix added when loading the glyphs-sprite meaning the sprite will be cached by the
+    browser. But you can easily manage the cache by providing
+    <code>SPRITE_CACHE_VERSION</code>
+    token in your app module. For example, you can use a service containing a version number to define the
+    <code>SPRITE_CACHE_VERSION</code>
+    :
+    <pre><code>{{cacheVersionExample}}</code></pre>
   </pa-demo-code>
 </pa-demo-page>

--- a/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
+++ b/projects/demo/src/app/demo/pages/popup-page/popup-page.component.html
@@ -74,8 +74,11 @@
     <dl>
       <dt>alignPopupOnLeft</dt>
       <dd>
-        Set the popup on the left of the element carrying the directive
-        <small>(default: false, meaning the popup is aligned on the right of the carrying directive by default)</small>
+        Align the left side of the popup on the left side of the element carrying the directive
+        <small>
+          (default: false, meaning the right side of the popup is aligned on the right of the carrying directive by
+          default)
+        </small>
       </dd>
 
       <dt>openOnly</dt>
@@ -104,14 +107,21 @@
 
       <dt>popupOnRight</dt>
       <dd>
-        Set the popup position to be on the right of the element carrying the directive
+        Align the left side of the popup on the right side of the element carrying the directive
         <small>(default: false)</small>
       </dd>
 
       <dt>popupOnTop</dt>
       <dd>
-        Set the popup position to be on top of the element carrying the directive
-        <small>(default: false)</small>
+        Align the bottom of the popup on top of the element carrying the directive.
+
+        <small>
+          (default: false.
+          <strong>Warning:</strong>
+          does not work when one of the popup’s parent has
+          <code>container-type: size</code>
+          set.)
+        </small>
       </dd>
 
       <dt>sameWidth</dt>

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.64.2",
+    "version": "2.64.3",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/common.ts
+++ b/projects/pastanaga-angular/src/lib/common.ts
@@ -63,6 +63,16 @@ export const getPositionedParent = (element: HTMLElement): HTMLElement => {
   }
 };
 
+export const hasContainerTypeSizeParent = (element: HTMLElement): boolean => {
+  const style = getComputedStyle(element);
+  const isContainerTypeSize = style.containerType !== 'normal';
+  if (isContainerTypeSize || element.tagName === 'BODY') {
+    return isContainerTypeSize;
+  }
+  const parent = element.parentElement;
+  return parent ? hasContainerTypeSizeParent(parent) : false;
+};
+
 export const getRealPosition = (element: HTMLElement): { top: number; left: number } => {
   let tmp: HTMLElement | null = element;
   let tagName = tmp.tagName.toLowerCase();

--- a/projects/pastanaga-angular/src/lib/common.ts
+++ b/projects/pastanaga-angular/src/lib/common.ts
@@ -63,14 +63,16 @@ export const getPositionedParent = (element: HTMLElement): HTMLElement => {
   }
 };
 
-export const hasContainerTypeSizeParent = (element: HTMLElement): boolean => {
+export const getContainerTypeSizeElement = (element: HTMLElement): HTMLElement | undefined => {
   const style = getComputedStyle(element);
   const isContainerTypeSize = style.containerType !== 'normal';
-  if (isContainerTypeSize || element.tagName === 'BODY') {
-    return isContainerTypeSize;
+  if (isContainerTypeSize) {
+    return element;
+  } else if (element.tagName === 'BODY') {
+    return undefined;
   }
   const parent = element.parentElement;
-  return parent ? hasContainerTypeSizeParent(parent) : false;
+  return parent ? getContainerTypeSizeElement(parent) : undefined;
 };
 
 export const getRealPosition = (element: HTMLElement): { top: number; left: number } => {

--- a/projects/pastanaga-angular/src/lib/icon/icon.component.ts
+++ b/projects/pastanaga-angular/src/lib/icon/icon.component.ts
@@ -3,7 +3,9 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
+  inject,
   Inject,
+  InjectionToken,
   Input,
   PLATFORM_ID,
   Renderer2,
@@ -15,6 +17,11 @@ import { SvgLoader } from './svg-loader';
 import { markForCheck, Size } from '../common';
 import { IconModel } from './icon.model';
 
+export const SPRITE_CACHE_VERSION = new InjectionToken<string>('Cache version used when loading SVG sprite', {
+  providedIn: 'root',
+  factory: () => '',
+});
+
 @Component({
   selector: 'pa-icon',
   templateUrl: './icon.component.html',
@@ -22,6 +29,8 @@ import { IconModel } from './icon.model';
   encapsulation: ViewEncapsulation.None,
 })
 export class IconComponent {
+  private readonly cacheVersion = inject(SPRITE_CACHE_VERSION);
+
   @Input() set icon(value: IconModel | null | undefined) {
     if (!value) {
       return;
@@ -39,7 +48,7 @@ export class IconComponent {
   @Input() set name(value: string) {
     if (!!value) {
       this._name = value;
-      this._spritePath = `assets/glyphs-sprite.svg#${this._name}`;
+      this._spritePath = `assets/glyphs-sprite.svg${this.cacheVersion ? '?' + this.cacheVersion : ''}#${this._name}`;
       this.updateStyle();
     }
   }

--- a/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.directive.ts
@@ -11,7 +11,7 @@ import {
   Renderer2,
   SimpleChanges,
 } from '@angular/core';
-import { hasContainerTypeSizeParent, PositionStyle } from '../common';
+import { getContainerTypeSizeElement, PositionStyle } from '../common';
 import { POPUP_OFFSET, PopupComponent } from './popup.component';
 import { Subject } from 'rxjs';
 import { takeUntil, throttleTime } from 'rxjs/operators';
@@ -35,6 +35,7 @@ export class PopupDirective implements OnInit, OnChanges, OnDestroy {
   private _scrollOrResize = new Subject<Event>();
   private _terminator = new Subject<void>();
   private _hasContainerSizeParent?: boolean;
+  private _containerSizeElement?: HTMLElement;
 
   constructor(
     private element: ElementRef,
@@ -99,15 +100,22 @@ export class PopupDirective implements OnInit, OnChanges, OnDestroy {
 
     let top: number;
     let bottom: number;
+    let containerRect: DOMRect | undefined;
 
     const parentElement: HTMLElement | null = directiveElement.parentElement;
     if (this._hasContainerSizeParent === undefined) {
-      this._hasContainerSizeParent = parentElement ? hasContainerTypeSizeParent(parentElement) : false;
+      this._containerSizeElement = parentElement ? getContainerTypeSizeElement(parentElement) : undefined;
+      this._hasContainerSizeParent = !!this._containerSizeElement;
     }
-    if (this._hasContainerSizeParent) {
+    if (this._hasContainerSizeParent && !!this._containerSizeElement) {
       // when a parent has `container-type: size` or `container-type: inline-size`,
       // the `position: fixed` are relative to the container and not to the window anymore
-      top = directiveRect.height + this.popupVerticalOffset;
+      containerRect = this._containerSizeElement.getBoundingClientRect();
+
+      const scrollTop = this._containerSizeElement.scrollTop;
+      top = directiveRect.top - containerRect.top + scrollTop + directiveRect.height + this.popupVerticalOffset;
+      // popup on top cannot be computed with container-size because it would require the popup height which is not set at this moment
+      // in this case we keep the popup below the directive
       bottom = this.popupVerticalOffset * -1;
     } else {
       top = directiveRect.top + directiveRect.height + this.popupVerticalOffset;
@@ -123,11 +131,15 @@ export class PopupDirective implements OnInit, OnChanges, OnDestroy {
 
     const bodyRect = document.body.getBoundingClientRect();
     if (this.alignPopupOnLeft) {
-      position.left = this._hasContainerSizeParent ? '0px' : `${directiveRect.left}px`;
+      position.left = !!containerRect ? `${directiveRect.left - containerRect.left}px` : `${directiveRect.left}px`;
     } else if (this.popupOnRight) {
-      position.left = this._hasContainerSizeParent ? `${directiveRect.width}px` : `${directiveRect.right}px`;
+      position.left = !!containerRect
+        ? `${directiveRect.left - containerRect.left + directiveRect.width}px`
+        : `${directiveRect.right}px`;
     } else {
-      position.right = this._hasContainerSizeParent ? '0px' : `${bodyRect.right - directiveRect.right}px`;
+      position.right = !!containerRect
+        ? `${containerRect.right - directiveRect.right}px`
+        : `${bodyRect.right - directiveRect.right}px`;
     }
 
     return position;


### PR DESCRIPTION
### Improvements

- **Icons**: New `SPRITE_CACHE_VERSION` injection token allowing to manage the cache version of svg sprite

### Bugfix

- **Popup**: Fix popup position when one of the popup’s parent has `container-type: size`

