### PR TITLE
Fix tooltip in options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # 2.64.4 (2023-01-04)
 
-### Bugfix
+### Bugfixes
 
 - **Tooltip**:
   - Fix tooltip position when directive parent has `container-type: size`
-  - Display tooltip from dropdown option on the first hover event 
+  - Display tooltip from dropdown option on the first hover event
+  - Prevent tooltip content to be duplicated
+  - Update ellipsis tooltip in options when dropdown is displayed
 
 # 2.64.3 (2023-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
   - Fix tooltip position when directive parent has `container-type: size`
   - Display tooltip from dropdown option on the first hover event
   - Prevent tooltip content to be duplicated
+- **Ellipsis Tooltip**:
   - Update ellipsis tooltip in options when dropdown is displayed
+  - Add `noEllipsis` option to disable the ellipsis tooltip if needed: we cannot optionally add ellipsis tooltip directive,
+but in some components like checkbox, we need the ability to display an ellipsis or not.
+`noEllipsis` option allows to use `paEllipsisTooltip` and optionally disable it.    
+- **Checkbox**: Display a tooltip when the label has en ellipsis
 
 # 2.64.3 (2023-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-# 2.64.4 (2023-12-29)
+# 2.64.4 (2023-01-04)
 
 ### Bugfix
 
-- **Tooltip**: Fix tooltip position when directive parent has `container-type: size`
+- **Tooltip**:
+  - Fix tooltip position when directive parent has `container-type: size`
+  - Display tooltip from dropdown option on the first hover event 
 
 # 2.64.3 (2023-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.64.4 (2023-12-29)
+
+### Bugfix
+
+- **Tooltip**: Fix tooltip position when directive parent has `container-type: size`
+
 # 2.64.3 (2023-12-19)
 
 ### Improvements

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
@@ -102,6 +102,7 @@
             #level1
             [companionElement]="level2Element?.nativeElement">
             <pa-option
+              id="level1option1"
               icon="chevron-right"
               iconOnRight
               dontCloseOnSelect
@@ -110,9 +111,10 @@
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'jedi'"
               (selectOption)="onLevel1Selection('jedi')">
-              Jedi
+              {{ 'demo-page.jedi' | translate }}
             </pa-option>
             <pa-option
+              id="level1option2"
               icon="chevron-right"
               iconOnRight
               dontCloseOnSelect
@@ -121,9 +123,10 @@
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'rebels'"
               (selectOption)="onLevel1Selection('rebels')">
-              Rebels
+              {{ 'demo-page.rebels' | translate }}
             </pa-option>
             <pa-option
+              id="level1option3"
               icon="chevron-right"
               iconOnRight
               dontCloseOnSelect
@@ -132,7 +135,7 @@
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'sith'"
               (selectOption)="onLevel1Selection('sith')">
-              Sith
+              {{ 'demo-page.sith' | translate }}
             </pa-option>
           </pa-dropdown>
 
@@ -223,7 +226,7 @@
 
           <pa-dropdown
             #level01
-            [companionElement]="level2Element?.nativeElement">
+            [companionElement]="level02Element?.nativeElement">
             <pa-option
               icon="chevron-right"
               iconOnRight
@@ -232,8 +235,8 @@
               [paPopup]="level02"
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'jedi'"
-              (selectOption)="onLevel1Selection('jedi')">
-              Jedi
+              (selectOption)="onLevel01Selection('jedi')">
+              Jedi Knights (may the force be with them)
             </pa-option>
             <pa-option
               icon="chevron-right"
@@ -243,7 +246,7 @@
               [paPopup]="level02"
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'rebels'"
-              (selectOption)="onLevel1Selection('rebels')">
+              (selectOption)="onLevel01Selection('rebels')">
               Rebels
             </pa-option>
             <pa-option
@@ -254,8 +257,8 @@
               [paPopup]="level02"
               [popupVerticalOffset]="-40"
               [selected]="level1Open === 'sith'"
-              (selectOption)="onLevel1Selection('sith')">
-              Sith
+              (selectOption)="onLevel01Selection('sith')">
+              Sith (Fear is the path to the dark side)
             </pa-option>
           </pa-dropdown>
 

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.html
@@ -269,7 +269,9 @@
               <pa-option
                 dontCloseOnSelect
                 (selectOption)="updateCheckbox(option, $event)">
-                <pa-checkbox [(value)]="option.checked">{{ option.label }}</pa-checkbox>
+                <pa-checkbox [(value)]="option.checked">
+                  {{ option.label }}
+                </pa-checkbox>
               </pa-option>
             }
           </pa-dropdown>

--- a/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
+++ b/projects/demo/src/app/demo/pages/dropdown-page/dropdown-page.component.ts
@@ -102,7 +102,9 @@ onLevel1Selection(selection: string) {
 }`;
 
   @ViewChild('level2', { read: ElementRef }) level2Element?: ElementRef;
+  @ViewChild('level02', { read: ElementRef }) level02Element?: ElementRef;
   @ViewChild('level2') level2Popup?: PopupComponent;
+  @ViewChild('level02') level02Popup?: PopupComponent;
   level1Open = '';
   level2Options: { label: string; checked?: boolean }[] = [];
 
@@ -113,9 +115,29 @@ onLevel1Selection(selection: string) {
   onLevel1Selection(selection: string) {
     this.level1Open = selection;
     this.level2Popup?.close();
+    this.updateLevel2Options(selection);
+  }
+
+  onLevel01Selection(selection: string) {
+    this.level1Open = selection;
+    this.level02Popup?.close();
+    this.updateLevel2Options(selection);
+  }
+
+  updateCheckbox(option: { label: string; checked?: boolean }, event: MouseEvent | KeyboardEvent) {
+    if ((event.target as HTMLElement).tagName === 'LI') {
+      option.checked = !option.checked;
+    }
+  }
+
+  private updateLevel2Options(selection: string) {
     switch (selection) {
       case 'jedi':
-        this.level2Options = [{ label: 'Yoda' }, { label: 'Obiwan Kenobi' }, { label: 'Luke Skywalker' }];
+        this.level2Options = [
+          { label: 'Yoda (Legendary Jedi Master)' },
+          { label: 'Obiwan Kenobi (Legendary Jedi Master)' },
+          { label: 'Luke Skywalker (Promising padawan)' },
+        ];
         break;
       case 'rebels':
         this.level2Options = [{ label: 'Leia Organa' }, { label: 'Han Solo' }, { label: 'Admiral Ackbar' }];
@@ -125,17 +147,6 @@ onLevel1Selection(selection: string) {
         break;
       default:
         this.level2Options = [];
-    }
-  }
-
-  closeDropdowns() {
-    this.level1Open = '';
-    this.level2Popup?.close();
-  }
-
-  updateCheckbox(option: { label: string; checked?: boolean }, event: MouseEvent | KeyboardEvent) {
-    if ((event.target as HTMLElement).tagName === 'LI') {
-      option.checked = !option.checked;
     }
   }
 }

--- a/projects/demo/src/app/demo/pages/ellipsis-tooltip-page/ellipsis-tooltip-page.component.html
+++ b/projects/demo/src/app/demo/pages/ellipsis-tooltip-page/ellipsis-tooltip-page.component.html
@@ -28,15 +28,24 @@
     </p>
     <p>Style responsible for the ellipsis will be added automatically, but you need to manage the container size.</p>
 
-    <h3>Inputs and outputs</h3>
+    <h3>Inputs</h3>
     <dl>
       <dt>paEllipsisContent</dt>
       <dd>
-        Triggers a
-        <code>hasEllipsis</code>
-        event after its first change.
+        By default, the tooltip contains the same text as its parent element. paEllipsisContent allows to change the
+        content of the tooltip displayed.
       </dd>
+      <dt>noEllipsis</dt>
+      <dd>
+        Allows to use
+        <code>paEllipsisTooltip</code>
+        on an element and optionally disable it.
+        <small>(False by default)</small>
+      </dd>
+    </dl>
 
+    <h3>Outputs</h3>
+    <dl>
       <dt>hasEllipsis</dt>
       <dd>
         Emit a boolean indicating if the content has an ellipsis or not. Event emitted on

--- a/projects/demo/src/assets/i18n/en.ts
+++ b/projects/demo/src/assets/i18n/en.ts
@@ -28,5 +28,8 @@ export const DEMO_EN: TranslationEntries = {
       latin: 'Latin',
     },
     'current-language-label': 'Current language',
+    jedi: 'Jedi Knights (may the force be with them)',
+    rebels: 'Rebels',
+    sith: 'Sith (Fear is the path to the dark side)',
   },
 };

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.64.3",
+    "version": "2.64.4",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/common.ts
+++ b/projects/pastanaga-angular/src/lib/common.ts
@@ -63,17 +63,31 @@ export const getPositionedParent = (element: HTMLElement): HTMLElement => {
   }
 };
 
-export const getContainerTypeSizeElement = (element: HTMLElement): HTMLElement | undefined => {
-  const style = getComputedStyle(element);
-  const isContainerTypeSize = style.containerType !== 'normal';
-  if (isContainerTypeSize) {
+export function getFixedRootParent(element: HTMLElement): HTMLElement {
+  if (element.tagName === 'BODY') {
     return element;
-  } else if (element.tagName === 'BODY') {
-    return undefined;
   }
-  const parent = element.parentElement;
-  return parent ? getContainerTypeSizeElement(parent) : undefined;
-};
+  // an element with `position: fixed` will be positioned relatively to the viewport
+  // unless one of the ancestor has a property `transform`, `filter`, `perspective`
+  // or has a containerType which is not normal
+  const style = getComputedStyle(element);
+  if (
+    style.transform !== 'none' ||
+    style.perspective !== 'none' ||
+    style.filter !== 'none' ||
+    style.containerType !== 'normal'
+  ) {
+    return element;
+  } else {
+    const parent = element.parentElement;
+    return parent ? getFixedRootParent(parent) : element;
+  }
+}
+
+export function getFixedRootParentIfAny(element: HTMLElement): HTMLElement | undefined {
+  const fixedRoot = getFixedRootParent(element);
+  return fixedRoot.tagName === 'BODY' ? undefined : fixedRoot;
+}
 
 export const getRealPosition = (element: HTMLElement): { top: number; left: number } => {
   let tmp: HTMLElement | null = element;

--- a/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/select/select.component.spec.ts
@@ -8,7 +8,7 @@ import { DropdownComponent, PaDropdownModule } from '../../../dropdown';
 import { PaPopupModule } from '../../../popup';
 import { SelectOptionsComponent } from './select-options/select-options.component';
 import { PaIconModule } from '../../../icon';
-import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
 import { OptionHeaderModel, OptionModel, OptionSeparator } from '../../control.model';
 import { SvgIconRegistryService } from 'angular-svg-icon';
 import { A11yModule, CdkMonitorFocus } from '@angular/cdk/a11y';
@@ -357,6 +357,7 @@ describe('SelectComponent', () => {
     expect(spectator.query('.pa-field-error')).toBeTruthy();
     expect(statusChanged).toHaveBeenCalledWith('INVALID');
     discardPeriodicTasks();
+    flush();
   }));
 
   it('should display errorMessages', fakeAsync(() => {
@@ -376,6 +377,7 @@ describe('SelectComponent', () => {
     spectator.detectChanges();
     expect(hint.componentInstance.errorMessages).toEqual({ required: 'field required' });
     discardPeriodicTasks();
+    flush();
   }));
 
   it('should render in dim mode', fakeAsync(() => {

--- a/projects/pastanaga-angular/src/lib/controls/textfield/typeahead-select/typeahead-select.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/controls/textfield/typeahead-select/typeahead-select.component.spec.ts
@@ -1,4 +1,4 @@
-import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
+import { discardPeriodicTasks, fakeAsync, flush, tick } from '@angular/core/testing';
 
 import { TypeaheadSelectComponent } from './typeahead-select.component';
 import { Component } from '@angular/core';
@@ -368,6 +368,7 @@ describe('TypeaheadSelectComponent', () => {
     expect(spectator.query('.pa-field-error')).toBeTruthy();
     expect(statusChanged).toHaveBeenCalledWith('INVALID');
     discardPeriodicTasks();
+    flush();
   }));
 
   it('should display errorMessages', fakeAsync(() => {
@@ -387,6 +388,7 @@ describe('TypeaheadSelectComponent', () => {
     spectator.detectChanges();
     expect(hint.componentInstance.errorMessages).toEqual({ required: 'field required' });
     discardPeriodicTasks();
+    flush();
   }));
 
   it('should render in dim mode', fakeAsync(() => {

--- a/projects/pastanaga-angular/src/lib/controls/toggles/checkbox/checkbox.component.html
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/checkbox/checkbox.component.html
@@ -16,7 +16,9 @@
     <label
       class="pa-toggle-label"
       [for]="id"
-      [class.no-ellipsis]="noEllipsis">
+      [class.no-ellipsis]="noEllipsis"
+      paEllipsisTooltip
+      [noEllipsis]="noEllipsis">
       <ng-content></ng-content>
     </label>
   </div>

--- a/projects/pastanaga-angular/src/lib/controls/toggles/toggles.module.ts
+++ b/projects/pastanaga-angular/src/lib/controls/toggles/toggles.module.ts
@@ -7,10 +7,11 @@ import { PaFormFieldModule } from '../form-field';
 import { ToggleComponent } from './toggle/toggle.component';
 import { RadioComponent } from './radio/radio.component';
 import { RadioGroupDirective } from './radio/radio-group.directive';
+import { PaTooltipModule } from '../../tooltip';
 
 @NgModule({
   declarations: [CheckboxComponent, ToggleComponent, RadioComponent, RadioGroupDirective],
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, PaFocusableModule, PaFormFieldModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, PaFocusableModule, PaFormFieldModule, PaTooltipModule],
   exports: [CheckboxComponent, ToggleComponent, RadioComponent, RadioGroupDirective],
 })
 export class PaTogglesModule {}

--- a/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.html
+++ b/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.html
@@ -1,12 +1,13 @@
-<div
-  class="pa-popup"
-  [hidden]="!isDisplayed"
-  [ngStyle]="style">
-  <div class="pa-popup-wrapper">
-    <ul
-      class="pa-menu"
-      [attr.role]="role">
-      <ng-content></ng-content>
-    </ul>
+@if (isDisplayed) {
+  <div
+    class="pa-popup"
+    [ngStyle]="style">
+    <div class="pa-popup-wrapper">
+      <ul
+        class="pa-menu"
+        [attr.role]="role">
+        <ng-content></ng-content>
+      </ul>
+    </div>
   </div>
-</div>
+}

--- a/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.html
+++ b/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.html
@@ -1,13 +1,12 @@
-@if (isDisplayed) {
-  <div
-    class="pa-popup"
-    [ngStyle]="style">
-    <div class="pa-popup-wrapper">
-      <ul
-        class="pa-menu"
-        [attr.role]="role">
-        <ng-content></ng-content>
-      </ul>
-    </div>
+<div
+  class="pa-popup"
+  [hidden]="!isDisplayed"
+  [ngStyle]="style">
+  <div class="pa-popup-wrapper">
+    <ul
+      class="pa-menu"
+      [attr.role]="role">
+      <ng-content></ng-content>
+    </ul>
   </div>
-}
+</div>

--- a/projects/pastanaga-angular/src/lib/dropdown/option/option.component.ts
+++ b/projects/pastanaga-angular/src/lib/dropdown/option/option.component.ts
@@ -65,6 +65,7 @@ export class OptionComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.text = this.element.nativeElement.textContent.trim();
+    this.cdr.markForCheck();
   }
 
   onSelectClick($event: MouseEvent) {

--- a/projects/pastanaga-angular/src/lib/modal/modal-advanced/modal-advanced.component.spec.ts
+++ b/projects/pastanaga-angular/src/lib/modal/modal-advanced/modal-advanced.component.spec.ts
@@ -5,12 +5,6 @@ import { MockModule, MockPipe } from 'ng-mocks';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { PaTranslateModule, TranslatePipe } from '../../translate';
 
-class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-global.ResizeObserver = ResizeObserver;
 describe('ModalComponent', () => {
   const title = 'Modal advanced title';
   const createComponent = createComponentFactory({

--- a/projects/pastanaga-angular/src/lib/tooltip/ellipsis-tooltip.directive.spec.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/ellipsis-tooltip.directive.spec.ts
@@ -15,7 +15,7 @@ describe('EllipsisTooltipDirective', () => {
         offsetWidth: 100,
         scrollWidth: 100,
         style: { setProperty: jest.fn() },
-        textContent: 'Text content of the element',
+        innerContent: 'Text content of the element',
       },
     };
   });

--- a/projects/pastanaga-angular/src/lib/tooltip/ellipsis-tooltip.directive.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/ellipsis-tooltip.directive.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  booleanAttribute,
   Directive,
   ElementRef,
   EventEmitter,
@@ -22,6 +23,7 @@ export class ExtendedTooltipDirective extends TooltipDirective {}
 })
 export class EllipsisTooltipDirective implements AfterViewInit, OnChanges, OnDestroy {
   @Input() paEllipsisContent?: string;
+  @Input({ transform: booleanAttribute }) noEllipsis?: string;
 
   @Output() hasEllipsis: EventEmitter<boolean> = new EventEmitter();
 
@@ -35,23 +37,27 @@ export class EllipsisTooltipDirective implements AfterViewInit, OnChanges, OnDes
   ) {}
 
   ngAfterViewInit() {
-    this.element.nativeElement.style.setProperty('overflow', 'hidden');
-    this.element.nativeElement.style.setProperty('text-overflow', 'ellipsis');
-    this.element.nativeElement.style.setProperty('white-space', 'nowrap');
-    if (this.element.nativeElement.offsetWidth === 0) {
-      this.resizeObserver.observe(this.element.nativeElement);
-    } else {
-      this.updateEllipsisTooltip();
+    if (!this.noEllipsis) {
+      this.element.nativeElement.style.setProperty('overflow', 'hidden');
+      this.element.nativeElement.style.setProperty('text-overflow', 'ellipsis');
+      this.element.nativeElement.style.setProperty('white-space', 'nowrap');
+      if (this.element.nativeElement.offsetWidth === 0) {
+        this.resizeObserver.observe(this.element.nativeElement);
+      } else {
+        this.updateEllipsisTooltip();
+      }
     }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    const currentValue = changes['paEllipsisContent']?.currentValue;
-    if (!!currentValue && !changes['paEllipsisContent'].firstChange) {
-      setTimeout(() => {
-        const previousValue = changes['paEllipsisContent']?.previousValue;
-        this.updateEllipsisTooltip(!!previousValue && currentValue !== previousValue);
-      }, 0);
+    if (!this.noEllipsis) {
+      const currentValue = changes['paEllipsisContent']?.currentValue;
+      if (!!currentValue && !changes['paEllipsisContent'].firstChange) {
+        setTimeout(() => {
+          const previousValue = changes['paEllipsisContent']?.previousValue;
+          this.updateEllipsisTooltip(!!previousValue && currentValue !== previousValue);
+        }, 0);
+      }
     }
   }
 

--- a/projects/pastanaga-angular/src/lib/tooltip/tooltip.component.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/tooltip.component.ts
@@ -1,12 +1,12 @@
 import {
   AfterViewInit,
-  Component,
-  ElementRef,
-  Input,
-  ViewChild,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
+  Component,
+  ElementRef,
   Inject,
+  Input,
+  ViewChild,
 } from '@angular/core';
 import { detectChanges, markForCheck } from '../common';
 import { WINDOW } from '@ng-web-apis/common';

--- a/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
@@ -9,7 +9,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import { TooltipComponent } from './tooltip.component';
-import { markForCheck, trimString } from '../common';
+import { getFixedRootParent, markForCheck, trimString } from '../common';
 
 const SYSTEM = 'system';
 const ACTION = 'action';
@@ -117,24 +117,9 @@ export class TooltipDirective {
       position = [event.clientX, event.clientY, rect.width, rect.height];
     }
     if (!this.rootParent) {
-      this.rootParent = this.getFixedRootParent(this.element.nativeElement);
+      this.rootParent = getFixedRootParent(this.element.nativeElement);
     }
     const rootRect = this.rootParent.getBoundingClientRect();
     return [position[0] - rootRect.left, position[1] - rootRect.top, position[2], position[3]];
-  }
-
-  getFixedRootParent(element: HTMLElement): HTMLElement {
-    if (element.tagName === 'BODY') {
-      return element;
-    }
-    // an element with `position: fixed` will be positioned relatively to the viewport
-    // unless one of the ancestor has a property `transform`, `filter` or `perspective`
-    const style = getComputedStyle(element);
-    if (style.transform !== 'none' || style.perspective !== 'none' || style.filter !== 'none') {
-      return element;
-    } else {
-      const parent = element.parentElement;
-      return parent ? this.getFixedRootParent(parent) : element;
-    }
   }
 }

--- a/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
+++ b/projects/pastanaga-angular/src/lib/tooltip/tooltip.directive.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { TooltipComponent } from './tooltip.component';
 import { getFixedRootParent, markForCheck, trimString } from '../common';
+import { BehaviorSubject } from 'rxjs';
 
 const SYSTEM = 'system';
 const ACTION = 'action';
@@ -25,9 +26,8 @@ export class TooltipDirective {
   @Input({ alias: 'paTooltipOffset', transform: numberAttribute }) offset = 0;
 
   id = '';
-  isDisplayed = false;
+  isDisplayed = new BehaviorSubject(false);
   rootParent?: HTMLElement;
-
   private component?: ComponentRef<TooltipComponent>;
 
   constructor(
@@ -51,21 +51,21 @@ export class TooltipDirective {
 
   @HostListener('mousemove', ['$event'])
   move(event: MouseEvent) {
-    if (!!this.text && this.isDisplayed && this.type === SYSTEM) {
+    if (!!this.text && this.isDisplayed.value && this.type === SYSTEM) {
       const position = this.getFixedPosition(event);
       this.show(position[0], position[1]);
     }
   }
 
   startDisplay(event: MouseEvent) {
-    if (!!this.text && !this.isDisplayed) {
+    if (!!this.text && !this.isDisplayed.value) {
       const position = this.getFixedPosition(event);
       if (!this.component) {
         this.createTooltip(position[0], position[1], position[2], position[3]);
       } else {
         this.show(position[0], position[1]);
       }
-      this.isDisplayed = true;
+      this.isDisplayed.next(true);
     }
   }
 
@@ -103,7 +103,7 @@ export class TooltipDirective {
     if (!!this.component) {
       this.component.instance.hide();
     }
-    this.isDisplayed = false;
+    this.isDisplayed.next(false);
   }
 
   getFixedPosition(event: MouseEvent): [number, number, number, number] {

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -26,5 +26,12 @@ Object.defineProperty(document.body.style, 'transform', {
   },
 });
 
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserver;
+
 /* output shorter and more meaningful Zone error stack traces */
 Error.stackTraceLimit = 2;


### PR DESCRIPTION
### Bugfixes

- **Tooltip**:
  - Fix tooltip position when directive parent has `container-type: size`
  - Display tooltip from dropdown option on the first hover event
  - Prevent tooltip content to be duplicated
- **Ellipsis Tooltip**:
  - Update ellipsis tooltip in options when dropdown is displayed
  - Add `noEllipsis` option to disable the ellipsis tooltip if needed: we cannot optionally add ellipsis tooltip directive,
but in some components like checkbox, we need the ability to display an ellipsis or not.
`noEllipsis` option allows to use `paEllipsisTooltip` and optionally disable it.    
- **Checkbox**: Display a tooltip when the label has en ellipsis
