### PR TITLE
Call blur when disabling a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
-# 2.64.5 (2023-01-29)
+# 2.64.6 (2024-02-12)
+
+### Bugfixes
+
+- **Text field**: when the field was programmatically disabled while the focus was in, the field still had the focus state (even though it didn't have the focus) when the field was then enabled again.
+To prevent this bug, we now call `blur` on the field on `setDisableState` method.
+
+# 2.64.5 (2024-01-29)
 
 ### Improvements
 
 - **Textarea**: add resizing event triggered by resizable textarea 
 
-# 2.64.4 (2023-01-04)
+# 2.64.4 (2024-01-04)
 
 ### Bugfixes
 

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.64.5",
+    "version": "2.64.6",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/controls/form-field/pa-form-control.directive.ts
+++ b/projects/pastanaga-angular/src/lib/controls/form-field/pa-form-control.directive.ts
@@ -235,6 +235,9 @@ export class PaFormControlDirective implements OnChanges, OnInit, OnDestroy, Con
       return;
     }
     if (isDisabled) {
+      // when setting the control to disable, we also call blur on the corresponding field
+      // otherwise the field keeps the focus state when it is enabled again
+      this.element.nativeElement.querySelector('.pa-field-control')?.blur();
       this.control.disable();
     } else {
       this.control.enable();


### PR DESCRIPTION
when a field was programmatically disabled while the focus was in, the field still had the focus state (even though it didn't have the focus) when the field was then enabled again.
To prevent this bug, we now call `blur` on the field on `setDisableState` method.