### PR TITLE
Close dropdown on scroll in position fixed container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.65.10 (2024-04-06)
+
+### Bug fix
+
+- **Dropdown**: when the dropdown is included in a container with `position: fixed` (like in a modal for instance), and in a scrollable container, we automatically close the dropdown on scroll event to prevent the dropdown to move while scrolling.
+
 # 2.65.9 (2024-04-05)
 
 ### Bug fix

--- a/projects/demo/src/app/demo/pages/modal-page/modal-example/modal-example.component.html
+++ b/projects/demo/src/app/demo/pages/modal-page/modal-example/modal-example.component.html
@@ -6,6 +6,13 @@
       <pa-input>Field 1</pa-input>
       <pa-input>Field 2</pa-input>
       <pa-input>Field 3</pa-input>
+      <pa-select label="Select">
+        <pa-option>Option 1</pa-option>
+        <pa-option>Option 2</pa-option>
+        <pa-option>Option 3</pa-option>
+        <pa-option>Option 4</pa-option>
+        <pa-option>Option 5</pa-option>
+      </pa-select>
       <pa-input>Field 4</pa-input>
       <pa-input>Field 5</pa-input>
       <p>

--- a/projects/pastanaga-angular/package.json
+++ b/projects/pastanaga-angular/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@guillotinaweb/pastanaga-angular",
     "description": "Provides Pastanaga UI elements as Angular components",
-    "version": "2.65.9",
+    "version": "2.65.10",
     "license": "MIT",
     "keywords": [
         "angular",

--- a/projects/pastanaga-angular/src/lib/common.ts
+++ b/projects/pastanaga-angular/src/lib/common.ts
@@ -89,6 +89,24 @@ export function getFixedRootParentIfAny(element: HTMLElement): HTMLElement | und
   return fixedRoot.tagName === 'BODY' ? undefined : fixedRoot;
 }
 
+export function hasPositionFixedParent(element: HTMLElement): boolean {
+  const fixedParent = getPositionedParent(element);
+  return fixedParent.tagName !== 'BODY';
+}
+
+export function getScrollableParent(element: HTMLElement): HTMLElement {
+  if (element.tagName === 'BODY') {
+    return element;
+  }
+  const style = getComputedStyle(element);
+  if (style.overflowY === 'auto' && element.scrollHeight > element.clientHeight) {
+    return element;
+  } else {
+    const parent = element.parentElement;
+    return parent ? getScrollableParent(parent) : element;
+  }
+}
+
 export const getRealPosition = (element: HTMLElement): { top: number; left: number } => {
   let tmp: HTMLElement | null = element;
   let tagName = tmp.tagName.toLowerCase();

--- a/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.ts
+++ b/projects/pastanaga-angular/src/lib/dropdown/dropdown.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -17,7 +18,7 @@ import { getScrollableParent, hasPositionFixedParent } from '../common';
   styleUrls: ['./dropdown.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DropdownComponent extends PopupComponent implements OnInit, OnDestroy {
+export class DropdownComponent extends PopupComponent implements AfterViewInit, OnInit, OnDestroy {
   @Input()
   set role(value: 'listbox' | 'menu') {
     this._role = value || 'menu';
@@ -43,19 +44,24 @@ export class DropdownComponent extends PopupComponent implements OnInit, OnDestr
     this.popupType = 'menu';
   }
 
-  override ngOnInit(): void {
-    super.ngOnInit();
-
+  ngAfterViewInit() {
     if (this._hasFixedRootParent === undefined && !this._fixedRootParentChecked) {
       const parentElement: HTMLElement | null = this.element.nativeElement.parentElement;
       this._hasFixedRootParent = !!parentElement && hasPositionFixedParent(parentElement);
       this._fixedRootParentChecked = true;
 
       if (parentElement && this._hasFixedRootParent) {
-        this._scrollableParent = getScrollableParent(parentElement);
-        this._scrollableParent.addEventListener('scroll', this.onScroll.bind(this));
+        // Make sure we wait for the full template to be enabled before getting the scrollable parent
+        setTimeout(() => {
+          this._scrollableParent = getScrollableParent(parentElement);
+          this._scrollableParent.addEventListener('scroll', this.onScroll.bind(this));
+        }, 0);
       }
     }
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
   }
 
   override ngOnDestroy() {

--- a/projects/pastanaga-angular/src/lib/popup/popup.component.ts
+++ b/projects/pastanaga-angular/src/lib/popup/popup.component.ts
@@ -44,7 +44,7 @@ export class PopupComponent implements OnInit, OnDestroy {
   private _id = '';
   private _handlers: (() => void)[] = [];
   private _originalHeight = 0;
-  private _terminator = new Subject<void>();
+  protected _terminator = new Subject<void>();
 
   constructor(
     protected popupService: PopupService,


### PR DESCRIPTION
when the dropdown is included in a container with `position: fixed` (like in a modal for instance), and in a scrollable container, we automatically close the dropdown on scroll event to prevent the dropdown to move while scrolling.